### PR TITLE
feat: support .mdx files in scan paths and allowed extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1399,6 +1399,7 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -1575,6 +1576,7 @@
       "integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.46.1",
@@ -2044,6 +2046,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2208,6 +2211,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2662,6 +2666,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2726,6 +2731,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2901,6 +2907,7 @@
       "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "^8.35.0",
         "comment-parser": "^1.4.1",
@@ -4479,6 +4486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5157,6 +5165,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5355,6 +5364,7 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -5388,6 +5398,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5515,6 +5526,7 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6028,6 +6040,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -6256,6 +6269,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -6281,6 +6295,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/boundaries/config-loader.ts
+++ b/src/boundaries/config-loader.ts
@@ -17,9 +17,10 @@ function parseBracketList(value: string): string[] {
 
 function isSupportedPattern(p: string): boolean {
   const last = p.split(/[\\/]/).pop() || p;
-  if (/\.(md|txt)$/i.test(last)) return true;
+  if (/\.(md|txt|mdx)$/i.test(last)) return true;
   if (/(^|\*)md$/i.test(last)) return true;
   if (/(^|\*)txt$/i.test(last)) return true;
+  if (/(^|\*)mdx$/i.test(last)) return true;
   return false;
 }
 
@@ -75,7 +76,7 @@ export function loadConfig(cwd: string = process.cwd()): Config {
   // Validate scan path patterns
   for (const pattern of scanPathsRaw) {
     if (!isSupportedPattern(pattern)) {
-      throw new ConfigError(`Only .md and .txt are supported in ScanPaths. Invalid pattern: ${pattern}`);
+      throw new ConfigError(`Only .md, .txt, and .mdx are supported in ScanPaths. Invalid pattern: ${pattern}`);
     }
   }
 

--- a/src/scan/file-resolver.ts
+++ b/src/scan/file-resolver.ts
@@ -2,7 +2,7 @@ import fg from 'fast-glob';
 import path from 'path';
 import { statSync } from 'fs';
 
-const ALLOWED_EXTS = new Set(['.md', '.txt']);
+const ALLOWED_EXTS = new Set(['.md', '.txt', '.mdx']);
 
 function isUnder(child: string, parent: string): boolean {
   const rel = path.relative(parent, child);


### PR DESCRIPTION
This pull request extends support for `.mdx` files across the config-loading and file-scanning logic. The main changes ensure that `.mdx` files are now treated as valid scan targets alongside `.md` and `.txt` files.

**File type support extension:**

* Updated the `isSupportedPattern` function in `src/boundaries/config-loader.ts` to recognize `.mdx` files as supported patterns.
* Modified the validation error message in `loadConfig` to include `.mdx` as a supported file type.
* Added `.mdx` to the set of allowed extensions in `src/scan/file-resolver.ts`, enabling scanning of `.mdx` files.