### PR TITLE
Remove Friction from Quick Start Guide

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,287 @@
+# VectorLint Configuration Guide
+
+A comprehensive reference for configuring VectorLint using `vectorlint.ini`.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Global Settings](#global-settings)
+- [LLM Providers](#llm-providers)
+- [Search Provider](#search-provider)
+- [File Pattern Sections](#file-pattern-sections)
+- [Rule-Specific Overrides](#rule-specific-overrides)
+- [Strictness Levels](#strictness-levels)
+- [Complete Example](#complete-example)
+
+---
+
+## Overview
+
+VectorLint uses a **file-centric configuration** approach. You specify which rule packs run on which files using glob patterns in `vectorlint.ini`.
+
+**Required Directory Structure:**
+
+```
+project/
+├── .github/
+│   └── rules/
+│       ├── Acme/                    ← Company style guide pack
+│       │   ├── grammar-checker.md
+│       │   ├── headline-evaluator.md
+│       │   └── Technical/           ← Nested organization supported
+│       │       └── technical-accuracy.md
+│       └── TechCorp/                ← Another company's pack
+│           └── brand-voice.md
+└── vectorlint.ini
+```
+
+---
+
+## Global Settings
+
+Global settings appear at the top of `vectorlint.ini` before any `[pattern]` sections.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `RulesPath` | string | `.github/rules` | Root directory containing your rule pack subdirectories |
+| `Concurrency` | integer | `4` | Number of concurrent evaluations to run |
+| `DefaultSeverity` | string | `warning` | Default severity level: `warning` or `error` |
+
+**Example:**
+
+```ini
+# Global settings
+RulesPath=.github/rules
+Concurrency=4
+DefaultSeverity=warning
+```
+
+---
+
+## LLM Providers
+
+VectorLint supports multiple LLM providers. Configure them using environment variables in your `.env` file.
+
+| Provider | `LLM_PROVIDER` Value | Required API Key Variable |
+|----------|----------------------|---------------------------|
+| **OpenAI** (Default) | `openai` | `OPENAI_API_KEY` |
+| **Anthropic** | `anthropic` | `ANTHROPIC_API_KEY` |
+| **Azure OpenAI** | `azure-openai` | *See `.env.example`* |
+| **Google Gemini** | `gemini` | `GEMINI_API_KEY` |
+
+---
+
+## Search Provider
+
+For rules that require external knowledge (like `technical-accuracy`), you can configure a search provider.
+
+| Setting | Environment Variable | Value | Description |
+|---------|----------------------|-------|-------------|
+| Provider | `SEARCH_PROVIDER` | `perplexity` | The search service to use |
+| API Key | `PERPLEXITY_API_KEY` | `pplx-...` | API key for the provider |
+
+**Setup:**
+
+Add these to your `.env` file:
+
+```bash
+SEARCH_PROVIDER=perplexity
+PERPLEXITY_API_KEY=your-key
+```
+
+---
+
+## File Pattern Sections
+
+Use `[glob/pattern]` sections to map file patterns to rule packs.
+
+### Syntax
+
+```ini
+[glob/pattern]
+RunRules=PackName
+```
+
+- **Pattern**: Standard glob pattern (e.g., `**/*.md`, `content/docs/**/*.md`)
+- **RunRules**: Name of the rule pack subdirectory to run on matching files
+  - Use company names (e.g., `Acme`, `TechCorp`) for style guide packs
+  - Leave empty (`RunRules=`) to skip all rules for matching files
+
+### Examples
+
+```ini
+# All markdown files - run Acme style guide
+[**/*.md]
+RunRules=Acme
+
+# Technical docs - run Acme pack
+[content/docs/**/*.md]
+RunRules=Acme
+
+# Marketing - run TechCorp pack
+[content/marketing/**/*.md]
+RunRules=TechCorp
+
+# Drafts - skip all rules
+[content/drafts/**/*.md]
+RunRules=
+```
+
+### Pattern Precedence
+
+When multiple patterns match a file, **the most specific pattern wins**. Specificity is determined by:
+
+1. **Exact matches** (highest priority)
+2. **Longer paths** (more specific)
+3. **Fewer wildcards** (more specific)
+
+**Example:**
+
+```ini
+# Less specific - applies to all markdown
+[**/*.md]
+RunRules=Acme
+
+# More specific - overrides for docs
+[content/docs/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=9
+```
+
+A file at `content/docs/api.md` will use the second pattern (higher strictness).
+
+---
+
+## Rule-Specific Overrides
+
+You can tune individual rules within a pattern section using `RuleID.parameter=value` syntax.
+
+### Syntax
+
+```ini
+[pattern]
+RunRules=PackName
+RuleID.parameter=value
+```
+
+- **RuleID**: The `id` field from the rule's YAML frontmatter
+- **parameter**: The specific setting to override (e.g., `strictness`, `threshold`)
+- **value**: The new value for this parameter
+
+### Common Overrides
+
+#### Strictness (Semi-Objective Rules)
+
+Controls the penalty weight for error density in semi-objective rules.
+
+```ini
+[content/blog/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=8
+```
+
+See [Strictness Levels](#strictness-levels) for the scale.
+
+#### Threshold (Subjective Rules)
+
+Sets the minimum passing score for subjective rules.
+
+```ini
+[content/marketing/**/*.md]
+RunRules=Acme
+HeadlineEvaluator.threshold=8.0
+```
+
+---
+
+## Strictness Levels
+
+For **semi-objective rules** (like grammar checkers), strictness controls how harshly errors are penalized based on error density.
+
+### The Scale (1-10)
+
+| Level | Name | Penalty | Use Case |
+|-------|------|---------|----------|
+| **1-3** | Lenient | 5 points per 1% error density | Drafts, brainstorming |
+| **4-7** | Standard | 10 points per 1% error density | General content |
+| **8-10** | Strict | 20 points per 1% error density | Published docs, legal content |
+
+### How It Works
+
+VectorLint scores based on **error density** (errors per 100 words):
+
+- **In a 100-word paragraph:** 1 error = 1% density
+  - Lenient (5): Lose 5 points
+  - Standard (10): Lose 10 points
+  - Strict (20): Lose 20 points
+
+- **In a 1,000-word article:** 1 error = 0.1% density
+  - Lenient (5): Lose 0.5 points
+  - Standard (10): Lose 1 point
+  - Strict (20): Lose 2 points
+
+**Starting score is always 10.0.** Scores below 10.0 trigger warnings or errors.
+
+### Examples
+
+```ini
+# Lenient for drafts
+[content/drafts/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=3
+
+# Standard for blog posts
+[content/blog/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=7
+
+# Strict for published docs
+[content/docs/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=9
+```
+
+---
+
+## Complete Example
+
+```ini
+# VectorLint Configuration
+# Global settings
+RulesPath=.github/rules
+Concurrency=4
+DefaultSeverity=warning
+
+# Default rules for all markdown files
+[**/*.md]
+RunRules=Acme
+
+# Blog content - standard strictness
+[content/blog/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=7
+HeadlineEvaluator.threshold=7.5
+
+# Technical documentation - higher strictness
+[content/docs/**/*.md]
+RunRules=Acme
+GrammarChecker.strictness=9
+TechnicalAccuracy.threshold=8.0
+
+# Marketing content - use custom pack
+[content/marketing/**/*.md]
+RunRules=TechCorp
+BrandVoice.strictness=8
+
+# Drafts - skip all rules
+[content/drafts/**/*.md]
+RunRules=
+```
+
+---
+
+## See Also
+
+- [Creating Rules](./CREATING_RULES.md) - How to write custom rules
+- [README](./README.md) - Installation and quick start
+- [Example Config](./vectorlint.ini.example) - Starter configuration template

--- a/CREATING_RULES.md
+++ b/CREATING_RULES.md
@@ -396,7 +396,8 @@ Scan for common AI patterns:
 ## Resources
 
 - [VectorLint README](./README.md) - Installation and basic usage
-- [Configuration Example](./vectorlint.ini.example) - Configuration options
+- [Configuration Guide](./CONFIGURATION.md) - Project configuration reference (`vectorlint.ini`)
+- [Configuration Example](./vectorlint.ini.example) - Starter configuration template
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,12 @@
-# VectorLint
+# VectorLint [![npm version](https://img.shields.io/npm/v/vectorlint.svg)](https://www.npmjs.com/package/vectorlint) [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-A command-line tool that evaluates Markdown content using LLMs and provides quality scores. Think of it like [Vale](https://github.com/errata-ai/vale), but instead of pattern matching, it uses LLMs enabling you to catch subjective issues like clarity, tone, and technical accuracy.
+VectorLint is a command-line tool that evaluates and scores content using LLMs. It uses [LLM-as-a-Judge](https://en.wikipedia.org/wiki/LLM-as-a-Judge) to catch subjective quality issues that traditional prose linters can't. 
 
 ![VectorLint Screenshot](./assets/VectorLint_screenshot.jpeg)
 
-## What You Can Do with VectorLint
-- **SEO Optimization** - Check if content follows SEO best practices.
-- **AI-Generated Content** - Detect AI-generated writing patterns.
-- **Technical Accuracy** - Verify claims and catch outdated or incorrect technical information
-- **Tone & Voice Consistency** - Ensure content matches appropriate tone for your audience
-
-If you can write a prompt for it, you can lint it with VectorLint.
-
-## Scoring System
-
-VectorLint uses a fair, density-based scoring system:
-
-*   **Semi-Objective (Density-Based):** Scores are calculated based on **errors per 100 words**. This ensures that a 1000-word article isn't penalized more than a 100-word paragraph for the same error rate. You can configure **Strictness** (Standard, Strict, Lenient) to control penalties.
-*   **Subjective (Normalized):** LLM ratings (1-4) are normalized to a **1-10 scale** using weighted averages, providing granular quality assessment.
-
 ## Installation
 
-### NPM Installation (Recommended)
+### Option 1: Global Installation
 
 Install globally from npm:
 
@@ -29,147 +14,96 @@ Install globally from npm:
 npm install -g vectorlint
 ```
 
-Or use with npx without installing:
-
-```bash
-npx vectorlint path/to/article.md
-```
-
-### Verify Installation
+Verify installation:
 
 ```bash
 vectorlint --help
 ```
 
+### Option 2: Zero-Install with npx
+
+Run VectorLint without installing:
+
+```bash
+npx vectorlint path/to/article.md
+```
+
+## Enforce Your Style Guide
+
+Define rules as Markdown files with YAML frontmatter to enforce your specific content standards:
+
+- **Check SEO Optimization** - Verify content follows SEO best practices
+- **Detect AI-Generated Content** - Identify artificial writing patterns
+- **Verify Technical Accuracy** - Catch outdated or incorrect technical information
+- **Ensure Tone & Voice Consistency** - Match content to appropriate tone for your audience
+
+If you can write a prompt for it, you can lint it with VectorLint.
+
+👉 **[Learn how to create custom rules →](./CREATING_RULES.md)**
+
+## Quality Scores
+VectorLint scores your content using error density and a rubric based system, enabling you to measure quality across documentation. This gives your team a shared understanding of which content needs attention and helps track improvements over time.
+*   **Density-Based Scoring:** For errors that can be counted, scores are calculated based on **error density (errors per 100 words)**, making quality assessment fair across documents of any length.
+*   **Rubric-Based Scoring:** For more subjective quality standards, like flow and completeness, scores are graded on a 1-4 rubric system and then normalized to a **1-10 scale**.
+
 ## Quick Start
 
-1.  **Configure Environment:**
+1.  **Create Your First Rule:**
 
-    ```bash
-    # Create .env file in your project directory
-    cp .env.example .env
-    # Edit .env with your API key (e.g., OPENAI_API_KEY)
+    Create a directory named `VectorLint` and add a file `grammar.md` inside it:
+
+    ```markdown
+    ---
+    evaluator: base
+    id: GrammarChecker
+    description: Grammar Checker
+    severity: error
+    ---
+    Check this content for grammar issues, spelling errors, and punctuation mistakes.
     ```
 
-2.  **Run a check:**
+2.  **Configure VectorLint:**
+
+    Create a `vectorlint.ini` configuration file in your project root:
+
+    ```ini
+    # vectorlint.ini
+    RulesPath=.
+    
+    # Run the "VectorLint" rule pack on all markdown files
+    [**/*.md]
+    RunRules=VectorLint
+    ```
+
+    👉 **[Full configuration reference →](./CONFIGURATION.md)**
+
+3.  **Set An LLM Provider:**
+
+    Create a `.env` file in your project root with your API keys:
+
+    ```bash
+    # OpenAI (Default)
+    OPENAI_API_KEY=sk-...
+    LLM_PROVIDER=openai
+
+    # - OR -
+    
+    # Anthropic
+    ANTHROPIC_API_KEY=sk-ant-...
+    LLM_PROVIDER=anthropic
+    ```
+
+4.  **Run a check:**
 
     ```bash
     vectorlint path/to/article.md
     ```
 
-## Configuration
+## Contributing
 
-### LLM Provider
+We welcome your contributions! Whether it's adding new rules, fixing bugs, or improving documentation, please check out our [Contributing Guidelines](.github/CONTRIBUTING.md) to get started.
 
-VectorLint supports multiple LLM providers:
+## Resources
 
-- **OpenAI**: GPT-4, GPT-3.5, and other OpenAI models
-- **Anthropic**: Claude (Opus, Sonnet, Haiku)
-- **Azure OpenAI**: Azure-hosted OpenAI models
-- **Google Gemini**: Gemini Pro and other Gemini models
-
-**Minimal Setup (OpenAI):**
-
-1.  Copy `.env.example` to `.env`.
-2.  Set `LLM_PROVIDER=openai`.
-3.  Set `OPENAI_API_KEY=your-key`.
-
-For other providers (Azure, Anthropic, Gemini), see the comments in `.env.example`.
-
-### Search Provider (Optional)
-
-For the `technical-accuracy` evaluator, you can optionally configure a search provider:
-
-- **Perplexity**: Set `SEARCH_PROVIDER=perplexity` and `PERPLEXITY_API_KEY` in `.env`
-
-### Project Config (vectorlint.ini)
-
-VectorLint uses a **file-centric configuration**. Evaluations are organized into **rule packs** (subdirectories), and you configure which packs run on which files.
-
-```bash
-cp vectorlint.example.ini vectorlint.ini
-```
-
-**Required Directory Structure:**
-
-Organize your evaluations into subdirectories (packs) within `RulesPath`:
-
-```
-.github/rules/
-  Acme/                    ← Company style guide pack
-    grammar-checker.md
-    headline-evaluator.md
-    Technical/             ← Nested organization supported
-      technical-accuracy.md
-  TechCorp/                ← Another company's style guide
-    brand-voice.md
-```
-
-**Configuration Format:**
-Use `[glob/pattern]` sections to specify which packs run on which files:
-
-```ini
-# Global settings
-RulesPath=.github/rules
-Concurrency=4
-DefaultSeverity=warning
-
-# All content - run Acme style guide
-[content/**/*.md]
-RunRules=Acme
-GrammarChecker.strictness=7
-
-# Technical docs - higher strictness
-[content/docs/**/*.md]
-RunRules=Acme
-GrammarChecker.strictness=9
-
-# Marketing - different company pack
-[content/marketing/**/*.md]
-RunRules=TechCorp
-
-# Drafts - skip all rules
-[content/drafts/**/*.md]
-RunRules=
-```
-
-**Key Settings:**
-- `RulesPath`: Root directory containing your rule pack subdirectories
-- `Concurrency`: Number of concurrent evaluations (default: 4)
-- `DefaultSeverity`: Default severity level (`warning` or `error`)
-- `[pattern]` sections: Map file patterns to rule packs using `RunRules`
-- Per-eval overrides: Tune specific evaluations (e.g., `GrammarChecker.strictness=9`)
-
-## Usage Guide
-
-### Creating Rules
-
-Rules are Markdown files with YAML frontmatter, organized into rule packs (subdirectories).
-
-**Example** (`Acme/tone-checker.md`):
-
-```markdown
----
-evaluator: base
-type: subjective
-id: ToneChecker
-name: Tone and Style Check
-severity: warning
-criteria:
-  - name: Friendliness
-    id: Friendliness
-    weight: 10
-  - name: Professionalism
-    id: Professionalism
-    weight: 8
----
-
-You are a tone evaluator. Assess the content for:
-
-1. **Friendliness**: Is the tone welcoming and approachable?
-2. **Professionalism**: Does it maintain professional writing quality?
-
-Provide a score (1-4) for each criterion with specific examples.
-```
-
-For detailed guidance, see [CREATING_RULES.md](./CREATING_RULES.md).
+- **[Creating Custom Rules](./CREATING_RULES.md)** - Write your own quality checks in Markdown
+- **[Configuration Guide](./CONFIGURATION.md)** - Complete reference for `vectorlint.ini`


### PR DESCRIPTION
## Changes
- **Refactored README.md**:
    - Reordered Quick Start (Rule -> Config -> Env -> Run) for logical flow.
    - Simplified installation (Global prioritized) and configuration instructions.
    - Moved detailed provider/config info to 
    - Added dedicated "Contributing" section.
- **Created CONFIGURATION.md**: New comprehensive reference for `vectorlint.ini`, LLM/Search providers, and strictness levels.
- **Improved DX**: Removed assumptions about cloning the repo (no more `cp .env.example`); added concrete, copy-pasteable examples for creating the first rule.