### PR TITLE
fix: resolve package.json path error in production build

### DIFF
--- a/src/output/json-formatter.ts
+++ b/src/output/json-formatter.ts
@@ -1,16 +1,12 @@
-import { createRequire } from 'node:module';
 import { z } from 'zod';
 import { Severity } from '../evaluators/types';
-
-const REQUIRE = createRequire(import.meta.url);
+import pkg from '../../package.json';
 
 const PACKAGE_JSON_SCHEMA = z.object({
   version: z.string(),
 });
 
-// Using require to load JSON in ESM
-const RAW_PACKAGE_JSON: unknown = REQUIRE('../../package.json');
-const PKG = PACKAGE_JSON_SCHEMA.parse(RAW_PACKAGE_JSON);
+const PKG = PACKAGE_JSON_SCHEMA.parse(pkg);
 export interface ScoreComponent {
   criterion?: string;
   rawScore: number;


### PR DESCRIPTION
The published package was crashing with` Error: Cannot find module '../../package.json'.` This occurred because the runtime code in `dist/index.js ` was trying to `require ../../package.json` relative to itself. While this path is correct in the source structure `(src/output/)`, the dist folder is flat, making the relative path invalid in the built artifact.

**Solution**

- Switched from runtime require() to a static import statement for package.json.
- Leveraged TypeScript's resolveJsonModule and tsup's bundling to inline the version number directly into the build output.
- This removes the runtime dependency on the package.json file location entirely.

**Verification**

- Verified local build runs without throwing module resolution errors.
- Checked dist/index.js to confirm package.json content is bundled