### PR TITLE
fix(cli): require explicit paths to prevent accidental directory scans

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -28,7 +28,7 @@ export function registerMainCommand(program: Command): void {
     .option('--debug-json', 'Print full JSON response from the API')
     .option('--output <format>', 'Output format: line (default), json, or vale-json, rdjson', 'line')
     .option(`--config <path>', 'Path to custom ${DEFAULT_CONFIG_FILENAME} config file`)
-    .argument('[paths...]', 'files or directories to check (optional)')
+    .argument('[paths...]', 'files or directories to check (required)')
     .action(async (paths: string[] = []) => {
       // Require explicit paths to prevent accidental full directory scans
       // Users must provide specific files, directories, or wildcards (e.g., `vectorlint *`)


### PR DESCRIPTION
## Problem

Running `vectorlint` without arguments defaulted to scanning all files 
in the directory (via `scanPaths` config), which:

- **Cost**: Triggers LLM calls for every file, consuming tokens unexpectedly
- **Safety**: Users might expect help/usage info, not a full scan
- **Best Practice**: Standard CLI tools don't default to resource-intensive operations

## Solution

Show help menu when no paths are provided. Users must now be explicit:

- `vectorlint *` - scan all files (explicit wildcard)
- `vectorlint .` - scan current directory
- `vectorlint path/to/file.md` - scan specific file

## Changes

- Added early exit in [commands.ts](cci:7://file:///c:/Users/User/Documents/work/vectorlint/src/cli/commands.ts:0:0-0:0) that calls `program.help()` when `paths` is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now requires explicit target paths. If none are provided, it displays help and exits early to avoid unintended processing; normal behavior continues when paths are supplied, preserving the usual command flow and outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->