### PR TITLE
Rename rule types from semi-objective/subjective to check/judge

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -152,7 +152,7 @@ RunRules=TechDocs
 Grammar.strictness=9
 ```
 
-You can configure the strictness of semi-objective rules (like Grammar or AI Detection) to control how they score content. Strictness determines the penalty weight for error density.
+You can configure the strictness of check rules (like Grammar or AI Detection) to control how they score content. Strictness determines the penalty weight for error density.
 
 ### Syntax
 

--- a/CREATING_RULES.md
+++ b/CREATING_RULES.md
@@ -7,8 +7,8 @@ A comprehensive guide to creating powerful, reusable content evaluations using V
 - [Overview](#overview)
 - [Rule Anatomy](#rule-anatomy)
 - [Evaluation Modes](#evaluation-modes)
-- [Semi-Objective Rules](#semi-objective-rules)
-- [Subjective Rules](#subjective-rules)
+- [Check Rules](#check-rules)
+- [Judge Rules](#judge-rules)
 - [Target Specification](#target-specification)
 - [Configuration Reference](#configuration-reference)
 - [Best Practices](#best-practices)
@@ -25,7 +25,7 @@ VectorLint rules are Markdown files with YAML frontmatter that define how your c
 - **Rule = Prompt file** (`.md` file organized in rule packs)
 - **Pack** = Subdirectory containing related rules (typically named after a company/style guide)
 - **Criteria** = Individual quality checks within a rule
-- **Score** = LLM-assigned rating (1-4 scale for subjective, density-based for semi-objective)
+- **Score** = LLM-assigned rating (1-4 scale for judge, density-based for check)
 
 - **Severity** = How failures are reported (`error` or `warning`)
 
@@ -41,7 +41,7 @@ Every rule is a Markdown file with two parts:
 id: MyEval
 name: My Content Evaluator
 evaluator: base
-type: semi-objective
+type: check
 severity: error
 ---
 
@@ -76,20 +76,20 @@ project/
 
 VectorLint uses a single **Base Evaluator** (`evaluator: base`) that operates in two distinct modes, determined by the `type` field:
 
-| Mode               | `type`           | Use Case                              | Scoring                     | Output                  |
-| ------------------ | ---------------- | ------------------------------------- | --------------------------- | ----------------------- |
-| **Semi-Objective** | `semi-objective` | Pass/fail checks, counting violations | 10 points - 1 per violation | List of specific issues |
-| **Subjective**     | `subjective`     | Multi-dimensional quality scoring     | 0-4 scale per criterion     | Weighted average score  |
+| Mode       | `type`  | Use Case                              | Scoring                     | Output                  |
+| ---------- | ------- | ------------------------------------- | --------------------------- | ----------------------- |
+| **Check**  | `check` | Pass/fail checks, counting violations | 10 points - 1 per violation | List of specific issues |
+| **Judge**  | `judge` | Multi-dimensional quality scoring     | 0-4 scale per criterion     | Weighted average score  |
 
 ### When to Use Each
 
-**Use Semi-Objective when:**
+**Use Check when:**
 
 - You need to find specific errors (e.g., "Find all grammar mistakes")
 - The check is binary (Pass/Fail) for each item
 - You want a list of specific violations to fix
 
-**Use Subjective when:**
+**Use Judge when:**
 
 - You're measuring quality on a spectrum (e.g., "How engaging is this?")
 - You have multiple dimensions (Clarity, Tone, Depth)
@@ -97,16 +97,16 @@ VectorLint uses a single **Base Evaluator** (`evaluator: base`) that operates in
 
 ---
 
-## Semi-Objective Rules
+## Check Rules
 
-Semi-objective rules are perfect for finding specific issues. The LLM lists violations, and the score is calculated based on the count of violations.
+Check rules are perfect for finding specific issues. The LLM lists violations, and the score is calculated based on the count of violations.
 
 ### Minimal Example
 
 ```markdown
 ---
 evaluator: base
-type: semi-objective
+type: check
 id: GrammarChecker
 name: Grammar Checker
 severity: error
@@ -141,9 +141,9 @@ Check this content for grammar issues, spelling errors, and punctuation mistakes
 
 ---
 
-## Subjective Rules
+## Judge Rules
 
-Subjective rules use weighted criteria and a 1-4 rubric for sophisticated quality measurement.
+Judge rules use weighted criteria and a 1-4 rubric for sophisticated quality measurement.
 
 ### Structure
 
@@ -151,7 +151,7 @@ Subjective rules use weighted criteria and a 1-4 rubric for sophisticated qualit
 ---
 specVersion: 1.0.0
 evaluator: base
-type: subjective
+type: judge
 id: HeadlineEvaluator
 name: Headline Evaluator
 
@@ -184,7 +184,7 @@ Clear benefit but less specific impact
 
 ### The 1-4 Scoring Scale
 
-VectorLint uses a **1-4 scale** for all subjective criteria, which is then normalized to a 1-10 scale:
+VectorLint uses a **1-4 scale** for all judge criteria, which is then normalized to a 1-10 scale:
 
 | LLM Rating | Meaning   | Normalized Score |
 | :--------- | :-------- | :--------------- |
@@ -247,14 +247,14 @@ target:
 | ------------- | ------------- | -------- | ------------------------------------------------------------------ |
 | `specVersion` | string/number | No       | Rule specification version (use `1.0.0`)                           |
 | `evaluator`   | string        | No       | Evaluator type: `base`, `technical-accuracy` (default: `base`)     |
-| `type`        | string        | No       | Mode: `subjective` or `semi-objective` (default: `semi-objective`) |
+| `type`        | string        | No       | Mode: `judge` or `check` (default: `check`) |
 | `id`          | string        | **Yes**  | Unique identifier (used in error reporting)                        |
 | `name`        | string        | **Yes**  | Human-readable name                                                |
 
 | `severity` | string | No | `error` or `warning` (default: `warning`) |
 | `evaluateAs` | string | No | `document` or `chunk` - whether to evaluate content as a whole or in chunks (default: `chunk`) |
 | `target` | object | No | Content matching specification |
-| `criteria` | array | **Yes\*** | List of evaluation criteria (\*required for subjective) |
+| `criteria` | array | **Yes\*** | List of evaluation criteria (\*required for judge) |
 
 ### Criterion Fields
 
@@ -323,12 +323,12 @@ Help the LLM understand your domain:
 
 ## Examples
 
-### Example 1: Simple Grammar Check (Semi-Objective)
+### Example 1: Simple Grammar Check (Check)
 
 ```markdown
 ---
 evaluator: base
-type: semi-objective
+type: check
 id: GrammarChecker
 name: Grammar Checker
 severity: error
@@ -338,13 +338,13 @@ Check this content for grammar issues, spelling errors, and punctuation mistakes
 Report any errors found with specific examples.
 ```
 
-### Example 2: Headline Evaluator (Subjective)
+### Example 2: Headline Evaluator (Judge)
 
 ```markdown
 ---
 specVersion: 1.0.0
 evaluator: base
-type: subjective
+type: judge
 id: Headline
 name: Headline Evaluator
 
@@ -380,13 +380,13 @@ Specific, immediately appealing benefit clearly stated
 ...
 ```
 
-### Example 3: AI Pattern Detector (Subjective)
+### Example 3: AI Pattern Detector (Judge)
 
 ```markdown
 ---
 specVersion: 1.0.0
 evaluator: base
-type: subjective
+type: judge
 id: AIPatterns
 name: AI Pattern Detector
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you can write a prompt for it, you can lint it with VectorLint.
 VectorLint scores your content using error density and a rubric-based system, enabling you to measure quality across documentation. This gives your team a shared understanding of which content needs attention and helps track improvements over time.
 
 - **Density-Based Scoring:** For errors that can be counted, scores are calculated based on **error density (errors per 100 words)**, making quality assessment fair across documents of any length.
-- **Rubric-Based Scoring:** For more subjective quality standards, like flow and completeness, scores are graded on a 1-4 rubric system and then normalized to a **1-10 scale**.
+- **Rubric-Based Scoring:** For more nuanced quality standards, like flow and completeness, scores are graded on a 1-4 rubric system and then normalized to a **1-10 scale**.
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3489,9 +3489,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5564,9 +5564,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.20",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
-      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectorlint",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "An LLM-based prose linter that lets you enforce your style guide in one prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/presets/VectorLint/ai-pattern.md
+++ b/presets/VectorLint/ai-pattern.md
@@ -1,6 +1,6 @@
 ---
 specVersion: 1.0.0
-type: semi-objective
+type: check
 severity: warning
 strictness: 50
 name: AI Pattern

--- a/presets/VectorLint/directness.md
+++ b/presets/VectorLint/directness.md
@@ -1,6 +1,6 @@
 ---
 specVersion: 1.0.0
-type: semi-objective
+type: check
 severity: warning
 strictness: 30
 name: Directness

--- a/presets/VectorLint/pseudo-advice.md
+++ b/presets/VectorLint/pseudo-advice.md
@@ -1,6 +1,6 @@
 ---
 specVersion: 1.0.0
-type: semi-objective
+type: check
 severity: warning
 strictness: 50
 name: Pseudo-Advice Detector

--- a/presets/VectorLint/repetition.md
+++ b/presets/VectorLint/repetition.md
@@ -1,6 +1,6 @@
 ---
 specVersion: 1.0.0
-type: semi-objective
+type: check
 severity: warning
 strictness: 50
 name: Repetition

--- a/src/evaluators/base-evaluator.ts
+++ b/src/evaluators/base-evaluator.ts
@@ -45,28 +45,29 @@ export class BaseEvaluator implements Evaluator {
     protected llmProvider: LLMProvider,
     protected prompt: PromptFile,
     protected defaultSeverity?: Severity
-  ) {}
+  ) { }
 
   async evaluate(_file: string, content: string): Promise<EvaluationResult> {
     const type = this.getEvaluationType();
 
-    if (type === EvaluationType.SUBJECTIVE) {
-      return this.runSubjectiveEvaluation(content);
+    if (type === EvaluationType.JUDGE) {
+      return this.runJudgeEvaluation(content);
     } else {
-      return this.runSemiObjectiveEvaluation(content);
+      return this.runCheckEvaluation(content);
     }
   }
 
   /*
    * Determines the evaluation type.
-   * Defaults to 'semi-objective' if not specified, for backward compatibility.
+   * Defaults to 'check' if not specified, for backward compatibility.
    */
   protected getEvaluationType():
-    | typeof EvaluationType.SUBJECTIVE
-    | typeof EvaluationType.SEMI_OBJECTIVE {
-    return this.prompt.meta.type === "subjective"
-      ? EvaluationType.SUBJECTIVE
-      : EvaluationType.SEMI_OBJECTIVE;
+    | typeof EvaluationType.JUDGE
+    | typeof EvaluationType.CHECK {
+    // After Zod transform, type will be 'judge' or 'check' (or undefined)
+    return this.prompt.meta.type === "judge"
+      ? EvaluationType.JUDGE
+      : EvaluationType.CHECK;
   }
 
   protected chunkContent(content: string): Chunk[] {
@@ -107,13 +108,13 @@ export class BaseEvaluator implements Evaluator {
   }
 
   /*
-   * Runs subjective evaluation:
+   * Runs judge evaluation:
    * 1. Prepend line numbers for accurate LLM line reporting.
    * 2. Chunk content if needed.
    * 3. LLM scores each criterion 1-4 for each chunk.
    * 4. Average scores across chunks (weighted by chunk size).
    */
-  protected async runSubjectiveEvaluation(
+  protected async runJudgeEvaluation(
     content: string
   ): Promise<SubjectiveResult> {
     const schema = buildSubjectiveLLMSchema();
@@ -175,14 +176,14 @@ export class BaseEvaluator implements Evaluator {
   }
 
   /*
-   * Runs semi-objective evaluation:
+   * Runs check evaluation:
    * 1. Prepend line numbers for accurate LLM line reporting.
    * 2. Chunk content if needed.
    * 3. LLM lists violations for each chunk.
    * 4. Merge all violations across chunks.
    * 5. Calculate score once from total violations.
    */
-  protected async runSemiObjectiveEvaluation(
+  protected async runCheckEvaluation(
     content: string
   ): Promise<SemiObjectiveResult> {
     const schema = buildSemiObjectiveLLMSchema();

--- a/src/evaluators/types.ts
+++ b/src/evaluators/types.ts
@@ -12,6 +12,6 @@ export enum Severity {
 }
 
 export enum EvaluationType {
-    SUBJECTIVE = 'subjective',
-    SEMI_OBJECTIVE = 'semi-objective',
+    JUDGE = 'judge',
+    CHECK = 'check',
 }

--- a/src/prompts/schema.ts
+++ b/src/prompts/schema.ts
@@ -3,7 +3,7 @@ import type { TokenUsage } from "../providers/token-usage";
 
 export function buildSubjectiveLLMSchema() {
   return {
-    name: "vectorlint_subjective_result",
+    name: "vectorlint_judge_result",
     strict: true,
     schema: {
       type: "object",
@@ -57,7 +57,7 @@ export function buildSubjectiveLLMSchema() {
 
 export function buildSemiObjectiveLLMSchema() {
   return {
-    name: "vectorlint_semi_objective_result",
+    name: "vectorlint_check_result",
     strict: true,
     schema: {
       type: "object",
@@ -121,7 +121,7 @@ export type SemiObjectiveLLMResult = {
 };
 
 export type SubjectiveResult = {
-  type: typeof EvaluationType.SUBJECTIVE;
+  type: typeof EvaluationType.JUDGE;
   final_score: number; // 1-10
   criteria: Array<{
     name: string;
@@ -152,7 +152,7 @@ export type SemiObjectiveItem = {
 };
 
 export type SemiObjectiveResult = {
-  type: typeof EvaluationType.SEMI_OBJECTIVE;
+  type: typeof EvaluationType.CHECK;
   final_score: number; // 1-10
   percentage: number;
   violation_count: number;
@@ -175,11 +175,11 @@ export type EvaluationResult = SubjectiveResult | SemiObjectiveResult;
 export function isSubjectiveResult(
   result: EvaluationResult
 ): result is SubjectiveResult {
-  return result.type === EvaluationType.SUBJECTIVE;
+  return result.type === EvaluationType.JUDGE;
 }
 
 export function isSemiObjectiveResult(
   result: EvaluationResult
 ): result is SemiObjectiveResult {
-  return result.type === EvaluationType.SEMI_OBJECTIVE;
+  return result.type === EvaluationType.CHECK;
 }

--- a/src/schemas/prompt-schemas.ts
+++ b/src/schemas/prompt-schemas.ts
@@ -27,17 +27,29 @@ export const PROMPT_CRITERION_SCHEMA = z.object({
  * - 'technical-accuracy': specialized evaluator with claim extraction + search
  *
  * Evaluation type:
- * - 'subjective': 1-4 scores per criterion, normalized to 1-10
- * - 'semi-objective': density-based scoring (errors per 100 words)
+ * - 'judge': 1-4 scores per criterion, normalized to 1-10
+ * - 'check': density-based scoring (errors per 100 words)
  *
- * Strictness factor for semi-objective scoring:
+ * Deprecated aliases (still supported):
+ * - 'subjective' → 'judge'
+ * - 'semi-objective' → 'check'
+ *
+ * Strictness factor for check scoring:
  * - Determines penalty weight per 1% error density.
  * - Default: 10
  */
 export const PROMPT_META_SCHEMA = z.object({
   specVersion: z.union([z.string(), z.number()]).optional(),
   evaluator: z.enum(["base", "technical-accuracy"]).optional(),
-  type: z.enum(["subjective", "semi-objective"]).optional(),
+  type: z
+    .enum(["judge", "check", "subjective", "semi-objective"])
+    .transform((val) => {
+      // Map deprecated values to new canonical values
+      if (val === "subjective") return "judge" as const;
+      if (val === "semi-objective") return "check" as const;
+      return val;
+    })
+    .optional(),
   id: z.string(),
   name: z.string(),
   severity: z.nativeEnum(Severity).optional(),
@@ -49,6 +61,7 @@ export const PROMPT_META_SCHEMA = z.object({
   // Determines how content is evaluated: 'chunk' (default) for chunked processing, 'document' for full document
   evaluateAs: z.enum(["document", "chunk"]).optional(),
 });
+
 
 // Complete prompt file schema
 export const PROMPT_FILE_SCHEMA = z.object({

--- a/src/scoring/scorer.ts
+++ b/src/scoring/scorer.ts
@@ -11,16 +11,16 @@ export interface SemiObjectiveScoringOptions {
   strictness?: number | "lenient" | "strict" | "standard" | undefined;
   defaultSeverity?: typeof Severity.WARNING | typeof Severity.ERROR | undefined;
   promptSeverity?:
-    | typeof Severity.WARNING
-    | typeof Severity.ERROR
-    | string
-    | undefined;
+  | typeof Severity.WARNING
+  | typeof Severity.ERROR
+  | string
+  | undefined;
 }
 
 export interface SubjectiveScoringOptions {
   promptCriteria?:
-    | Array<{ name: string; weight?: number | undefined }>
-    | undefined;
+  | Array<{ name: string; weight?: number | undefined }>
+  | undefined;
 }
 
 function resolveStrictness(
@@ -41,7 +41,7 @@ function resolveStrictness(
 }
 
 /**
- * Calculates semi-objective score based on violation density.
+ * Calculates check score based on violation density.
  *
  * Formula: Score = (100 - (violations/wordCount * 100 * strictness)) / 10
  */
@@ -83,13 +83,12 @@ export function calculateSemiObjectiveScore(
 
   const message =
     mappedViolations.length > 0
-      ? `Found ${mappedViolations.length} issue${
-          mappedViolations.length > 1 ? "s" : ""
-        }`
+      ? `Found ${mappedViolations.length} issue${mappedViolations.length > 1 ? "s" : ""
+      }`
       : "No issues found";
 
   return {
-    type: EvaluationType.SEMI_OBJECTIVE,
+    type: EvaluationType.CHECK,
     final_score: Number(finalScore.toFixed(1)),
     percentage: Number(rawScore.toFixed(1)),
     violation_count: mappedViolations.length,
@@ -101,7 +100,7 @@ export function calculateSemiObjectiveScore(
 }
 
 /**
- * Calculates subjective score from criteria results.
+ * Calculates judge score from criteria results.
  *
  * Each criterion score (1-4) is normalized to 1-10 scale,
  * then weighted average is calculated.
@@ -138,20 +137,20 @@ export function calculateSubjectiveScore(
   const finalScore = totalWeight > 0 ? totalWeightedScore / totalWeight : 1;
 
   return {
-    type: EvaluationType.SUBJECTIVE,
+    type: EvaluationType.JUDGE,
     final_score: Number(finalScore.toFixed(1)),
     criteria: criteriaWithCalculations,
   };
 }
 
-// Averages subjective scores from multiple chunk evaluations.
+// Averages judge scores from multiple chunk evaluations.
 export function averageSubjectiveScores(
   results: SubjectiveResult[],
   chunkWordCounts: number[]
 ): SubjectiveResult {
   if (results.length === 0) {
     return {
-      type: EvaluationType.SUBJECTIVE,
+      type: EvaluationType.JUDGE,
       final_score: 0,
       criteria: [],
     };
@@ -161,7 +160,7 @@ export function averageSubjectiveScores(
   if (results.length !== chunkWordCounts.length) {
     console.warn(
       `[vectorlint] Array length mismatch in averageSubjectiveScores: ` +
-        `${results.length} results vs ${chunkWordCounts.length} word counts`
+      `${results.length} results vs ${chunkWordCounts.length} word counts`
     );
   }
 
@@ -275,7 +274,7 @@ export function averageSubjectiveScores(
   const finalScore = totalWeight > 0 ? totalWeightedScore / totalWeight : 0;
 
   return {
-    type: EvaluationType.SUBJECTIVE,
+    type: EvaluationType.JUDGE,
     final_score: Number(finalScore.toFixed(1)),
     criteria: aggregatedCriteria,
   };

--- a/tests/scoring-types.test.ts
+++ b/tests/scoring-types.test.ts
@@ -14,16 +14,17 @@ describe("Scoring Types", () => {
     runPromptStructured: vi.fn(),
   } as unknown as LLMProvider;
 
-  describe("Subjective Evaluation", () => {
-    const subjectivePrompt: PromptFile = {
-      id: "test-subjective",
+  describe("Judge Evaluation", () => {
+    const judgePrompt: PromptFile = {
+      id: "test-judge",
       filename: "test.md",
       fullPath: "/test.md",
       body: "Evaluate this.",
+      pack: "test",
       meta: {
-        id: "test-subjective",
-        name: "Test Subjective",
-        type: "subjective",
+        id: "test-judge",
+        name: "Test Judge",
+        type: "judge",
         criteria: [
           { id: "c1", name: "Criterion 1", weight: 50 },
           { id: "c2", name: "Criterion 2", weight: 50 },
@@ -32,7 +33,7 @@ describe("Scoring Types", () => {
     };
 
     it("should calculate weighted average correctly", async () => {
-      const evaluator = new BaseEvaluator(mockLlmProvider, subjectivePrompt);
+      const evaluator = new BaseEvaluator(mockLlmProvider, judgePrompt);
 
       // Mock LLM returning raw scores (0-4) wrapped in LLMResult
       const mockLlmResponse: LLMResult<SubjectiveLLMResult> = {
@@ -62,7 +63,7 @@ describe("Scoring Types", () => {
 
       const result = await evaluator.evaluate("file.md", "content");
 
-      if (result.type !== EvaluationType.SUBJECTIVE)
+      if (result.type !== EvaluationType.JUDGE)
         throw new Error("Wrong result type");
 
       // Calculation:
@@ -76,21 +77,22 @@ describe("Scoring Types", () => {
     });
   });
 
-  describe("Semi-Objective Evaluation", () => {
-    const semiObjectivePrompt: PromptFile = {
+  describe("Check Evaluation", () => {
+    const checkPrompt: PromptFile = {
       id: "test-semi",
       filename: "test.md",
       fullPath: "/test.md",
       body: "Count things.",
+      pack: "test",
       meta: {
         id: "test-semi",
         name: "Test Semi",
-        type: "semi-objective",
+        type: "check",
       },
     };
 
     it("should calculate score correctly based on violation count", async () => {
-      const evaluator = new BaseEvaluator(mockLlmProvider, semiObjectivePrompt);
+      const evaluator = new BaseEvaluator(mockLlmProvider, checkPrompt);
 
       // Mock LLM returning violations only wrapped in LLMResult
       const mockLlmResponse: LLMResult<SemiObjectiveLLMResult> = {
@@ -123,7 +125,7 @@ describe("Scoring Types", () => {
       const content = new Array(100).fill("word").join(" ");
       const result = await evaluator.evaluate("file.md", content);
 
-      if (result.type !== EvaluationType.SEMI_OBJECTIVE)
+      if (result.type !== EvaluationType.CHECK)
         throw new Error("Wrong result type");
 
       // Calculation: 2 violations = score of 8 (10 - 2)
@@ -133,7 +135,7 @@ describe("Scoring Types", () => {
     });
 
     it("should handle empty violations list (perfect score)", async () => {
-      const evaluator = new BaseEvaluator(mockLlmProvider, semiObjectivePrompt);
+      const evaluator = new BaseEvaluator(mockLlmProvider, checkPrompt);
 
       const mockLlmResponse: LLMResult<SemiObjectiveLLMResult> = {
         data: {
@@ -147,7 +149,7 @@ describe("Scoring Types", () => {
 
       const result = await evaluator.evaluate("file.md", "content");
 
-      if (result.type !== EvaluationType.SEMI_OBJECTIVE)
+      if (result.type !== EvaluationType.CHECK)
         throw new Error("Wrong result type");
 
       // No violations = perfect score
@@ -180,7 +182,8 @@ describe("Scoring Types", () => {
         filename: "tech.md",
         fullPath: "/tech.md",
         body: "Check accuracy",
-        meta: { id: "tech-acc", name: "Tech Acc", type: "semi-objective" },
+        pack: "test",
+        meta: { id: "tech-acc", name: "Tech Acc", type: "check" },
       };
 
       const evaluator = new TechnicalAccuracyEvaluator(
@@ -196,7 +199,7 @@ describe("Scoring Types", () => {
 
       const result = await evaluator.evaluate("file.md", "content");
 
-      if (result.type !== EvaluationType.SEMI_OBJECTIVE)
+      if (result.type !== EvaluationType.CHECK)
         throw new Error("Wrong result type");
       expect(result.final_score).toBe(10);
       expect(result.items).toEqual([]);


### PR DESCRIPTION
BREAKING CHANGE: Rule type terminology has changed
- 'semi-objective' → 'check'
- 'subjective' → 'judge'

Backward compatibility is maintained via Zod schema transform. Existing configs using old type names will continue to work.

Changes:
- Update EvaluationType enum with new JUDGE/CHECK values
- Add Zod transform to map deprecated values to new canonical values
- Rename internal methods to runJudgeEvaluation/runCheckEvaluation
- Update all VectorLint preset rules to use type: check
- Update CREATING_RULES.md, CONFIGURATION.md, README.md documentation
- Fix missing 'pack' property in test fixtures
- Apply npm audit fixes for glob and js-yaml vulnerabilities
- Bump version to 2.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v2.2.0

* **Documentation**
  * Updated terminology across configuration documentation, rule creation guides, and README for enhanced clarity and consistency.
  * Refined descriptions of scoring methodologies and evaluation approaches.

* **Chores**
  * Version bump to 2.2.0.
  * Updated preset definitions and metadata with new terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->