### PR TITLE
fix(schema): allow null system_fingerprint in OpenAI response

### DIFF
--- a/src/schemas/openai-responses.ts
+++ b/src/schemas/openai-responses.ts
@@ -33,7 +33,7 @@ export const OPENAI_RESPONSE_SCHEMA = z.object({
   model: z.string().optional(),
   choices: z.array(OPENAI_CHOICE_SCHEMA).min(1),
   usage: OPENAI_USAGE_SCHEMA.optional(),
-  system_fingerprint: z.string().optional(),
+  system_fingerprint: z.string().nullable().optional(),
 });
 
 // Inferred TypeScript types


### PR DESCRIPTION
The OpenAI API sometimes returns system_fingerprint: null in the response (observed with gpt-5.1-2025-11-13). Our Zod schema only allowed string | undefined, causing a validation error:

APIResponseError: Invalid OpenAI API response structure: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": ["system_fingerprint"],
    "message": "Expected string, received null"
  }
]

**Solution**

Updated OPENAI_RESPONSE_SCHEMA in 
src/schemas/openai-responses.ts
 to use .nullable().optional():


This allows:

undefined (field missing)
null (field explicitly null)
string (field with value)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved OpenAI API response handling to better manage edge cases in response validation and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->