### PR TITLE
docs: complete CLI reference, troubleshooting, and release notes 

### DIFF
--- a/.vectorlint.ini.example
+++ b/.vectorlint.ini.example
@@ -12,15 +12,13 @@ DefaultSeverity=warning
 [**/*.md]
 RunRules=Acme
 
-# Blog content with custom overrides
+# Blog content
 [content/blog/**/*.md]
 RunRules=Acme
-GrammarChecker.strictness=8
 
-# Technical documentation - higher strictness
+# Technical documentation
 [content/docs/**/*.md]
 RunRules=Acme
-GrammarChecker.strictness=9
 
 # Marketing content - use custom pack
 [content/marketing/**/*.md]

--- a/CREATING_RULES.md
+++ b/CREATING_RULES.md
@@ -415,7 +415,7 @@ Scan for common AI patterns:
 
 - [VectorLint README](./README.md) - Installation and basic usage
 - [Configuration Guide](./CONFIGURATION.md) - Project configuration reference (`.vectorlint.ini`)
-- [Configuration Example](./vectorlint.ini.example) - Starter configuration template
+- [Configuration Example](./.vectorlint.ini.example) - Starter configuration template
 
 ---
 

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -7,7 +7,7 @@ VectorLint runs from the command line. This page is the complete reference for e
 
 ## Basic usage
 
-The default command reviews one or more files and prints findings to standard output. You must pass at least one path — without one, VectorLint prints help.
+The default command reviews one or more files and prints findings to standard output. You must pass at least one path; without one, VectorLint prints help.
 
 ```bash
 vectorlint [flags] <file> [files...]
@@ -90,9 +90,9 @@ The default command (`vectorlint <paths>`) accepts these flags:
 
 With `--debug-json`, VectorLint writes one JSON artifact per evaluation to `.vectorlint/runs/<model-tag>/<run-id>.json`. Each artifact contains:
 
-- `raw_model_output` — exact JSON the model returned, including all evidence fields
-- `filter_decisions` — the deterministic surface/hide decision for each candidate, with reasons
-- `surfaced_violations` — the candidates that passed all confidence checks
+- `raw_model_output`: exact JSON the model returned, including all evidence fields
+- `filter_decisions`: the deterministic surface/hide decision for each candidate, with reasons
+- `surfaced_violations`: the candidates that passed all confidence checks
 
 Use these to compare how different models respond to the same rules and content, or to tune `CONFIDENCE_THRESHOLD`. The `.vectorlint/runs/` directory is gitignored.
 
@@ -168,7 +168,7 @@ Use this when running VectorLint in reviewdog or a reviewdog-compatible CI setup
 
 ## Exit codes
 
-The default command exits non-zero only when a finding surfaces at **`error`** severity — not for `warning`-severity findings. This lets warnings pass through CI while errors block a merge.
+The default command exits non-zero only when a finding surfaces at **`error`** severity, not for `warning`-severity findings. This lets warnings pass through CI while errors block a merge.
 
 | Code | Meaning |
 |------|---------|
@@ -196,7 +196,7 @@ For the full environment variable reference, including Azure OpenAI and Amazon B
 
 ## Related
 
-- [Installation](/installation) — install VectorLint globally or run with npx
-- [Configuration](/configuration) — configure VectorLint for your project
-- [Handling false positives](/handling-false-positives) — adjust `CONFIDENCE_THRESHOLD` and strictness
-- [CI Integration](/ci-integration) — use exit codes and output formats to gate merges
+- [Installation](/installation): install VectorLint globally or run with npx
+- [Configuration](/configuration): configure VectorLint for your project
+- [Handling false positives](/handling-false-positives): adjust `CONFIDENCE_THRESHOLD` and strictness
+- [CI Integration](/ci-integration): use exit codes and output formats to gate merges

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -1,23 +1,25 @@
 ---
 title: CLI reference
-description: Complete reference for the VectorLint command-line interface, including commands, flags, and exit codes.
+description: Complete reference for the VectorLint command-line interface, including commands, flags, output formats, and exit codes.
 ---
 
-VectorLint runs from the command line. You invoke it against one or more files and it prints findings to standard output. This page is the complete reference for all commands, flags, and exit behavior.
+VectorLint runs from the command line. This page is the complete reference for every command, flag, output format, and exit code.
 
 ## Basic usage
+
+The default command reviews one or more files and prints findings to standard output. You must pass at least one path — without one, VectorLint prints help.
 
 ```bash
 vectorlint [flags] <file> [files...]
 ```
 
-Run a review against one file:
+Review a single file:
 
 ```bash
 vectorlint doc.md
 ```
 
-Run against multiple files or a glob pattern:
+Review multiple files or a glob pattern:
 
 ```bash
 vectorlint content/docs/**/*.md
@@ -25,58 +27,155 @@ vectorlint content/docs/**/*.md
 
 ## Commands
 
+### `vectorlint <paths>`
+
+The default command. Reviews the given files against the rules that apply to them and prints findings. Accepts the [flags](#flags) below.
+
 ### `vectorlint init`
 
-Initializes VectorLint in your project. Generates configuration files based on the mode you choose.
+Generates configuration files for a project. The flags control which files are created; a global config is always ensured.
+
+| Flag | Effect |
+|------|--------|
+| _(none)_ | Creates `.vectorlint.ini` (project) and ensures `~/.vectorlint/config.toml` (global) |
+| `--quick` | Zero-config mode: creates only `VECTORLINT.md`. No `.vectorlint.ini` |
+| `--full` | Creates both `.vectorlint.ini` and `VECTORLINT.md`, and ensures the global config |
+| `--force` | Overwrite configuration files that already exist |
 
 ```bash
-vectorlint init
+vectorlint init          # project config + global config
+vectorlint init --quick  # VECTORLINT.md only (zero-config)
+vectorlint init --full   # project config + VECTORLINT.md + global config
 ```
 
-Creates two files:
+If a target file already exists, `init` exits with an error unless you pass `--force`.
 
-| File | Location | Purpose |
-|------|----------|---------|
-| `.vectorlint.ini` | Project root | File patterns and rule packs |
-| `config.toml` | `~/.vectorlint/` | LLM provider API keys |
+### `vectorlint validate`
 
-#### `--quick` flag
+Validates rule and prompt files **without running evaluations**. Checks YAML frontmatter structure, schema compliance, and prompt completeness, then prints a per-file report and a summary line.
 
 ```bash
-vectorlint init --quick
+vectorlint validate
 ```
 
-Zero-config mode. Creates only a `VECTORLINT.md` file in your project root. VectorLint detects it automatically and creates a "Style Guide Compliance" rule from its contents. No `.vectorlint.ini` required.
-
-### `vectorlint --help`
-
-Prints available commands and flags.
+By default, `validate` uses `RulesPath` from your project configuration. Override the rules directory:
 
 ```bash
-vectorlint --help
+vectorlint validate --rules .github/rules
+```
+
+Exits with code `1` if any validation errors are found; `0` otherwise. Use this to catch malformed rules before they reach a review.
+
+### `vectorlint --help` and `vectorlint --version`
+
+```bash
+vectorlint --help     # list commands and flags
+vectorlint --version  # print the installed version
 ```
 
 ## Flags
 
+The default command (`vectorlint <paths>`) accepts these flags:
+
 | Flag | Description |
 |------|-------------|
-| `--help` | Print help and exit |
-| `--version` | Print the installed VectorLint version and exit |
+| `-v`, `--verbose` | Enable verbose logging. Prints what VectorLint loads (directive, user instructions, rule packs) and extra detail during the review |
+| `--show-prompt` | Print the full prompt and injected content that is sent to the LLM |
+| `--show-prompt-trunc` | Print truncated prompt and content previews (first 500 characters). Useful for a quick check without the full payload |
+| `--debug-json` | Write a debug JSON artifact per evaluation under `.vectorlint/runs/` (see below) |
+| `--output <format>` | Output format. One of `line` (default), `json`, `vale-json`, `rdjson`. See [Output formats](#output-formats) |
+| `--config <path>` | Path to a custom `.vectorlint.ini` instead of the one in the project root |
 
-## Output
+### `--debug-json` artifacts
 
-VectorLint prints findings to standard output. Each finding includes the rule that triggered it, the location in the file, the specific violation, and a suggested fix.
+With `--debug-json`, VectorLint writes one JSON artifact per evaluation to `.vectorlint/runs/<model-tag>/<run-id>.json`. Each artifact contains:
 
-A file with no violations produces no output.
+- `raw_model_output` — exact JSON the model returned, including all evidence fields
+- `filter_decisions` — the deterministic surface/hide decision for each candidate, with reasons
+- `surfaced_violations` — the candidates that passed all confidence checks
+
+Use these to compare how different models respond to the same rules and content, or to tune `CONFIDENCE_THRESHOLD`. The `.vectorlint/runs/` directory is gitignored.
+
+## Output formats
+
+Control the output shape with `--output <format>`. The default `line` format is for humans; the others are for tooling and CI integration.
+
+### `line` (default)
+
+Human-readable terminal output. Each finding shows the rule, its location in the file, the violation, and a suggested fix. The run ends with a global summary and token usage. Findings are colored by severity.
+
+### `json`
+
+Native VectorLint JSON. Use this when you process VectorLint output yourself. The top-level object is:
+
+```json
+{
+  "files": {
+    "doc.md": {
+      "issues": [
+        {
+          "line": 12,
+          "column": 1,
+          "severity": "error",
+          "message": "Passive voice weakens the opening.",
+          "rule": "Acme.PassiveVoice",
+          "suggestion": "Rewrite in active voice."
+        }
+      ],
+      "evaluationScores": []
+    }
+  },
+  "summary": { "files": 1, "errors": 1, "warnings": 0 },
+  "metadata": { "version": "2.5.0", "timestamp": "2026-03-04T15:14:49Z" }
+}
+```
+
+Each issue includes `message` (the user-facing summary) and, when the model produced it, `analysis` (internal model reasoning). `evaluationScores` carries the per-rule score breakdown.
+
+### `vale-json`
+
+Compatible with tools that consume [Vale](https://vale.sh)'s JSON output. The shape is:
+
+```json
+{
+  "files": { "doc.md": [ /* ValeIssue[] */ ] },
+  "summary": { "files": 1, "errors": 1, "warnings": 0, "suggestions": 0 }
+}
+```
+
+Use this to plug VectorLint into an existing Vale-based pipeline.
+
+### `rdjson`
+
+[reviewdog](https://github.com/reviewdog/reviewdog)-compatible JSON (also used by GitHub Actions annotations). The shape is:
+
+```json
+{
+  "source": { "name": "vectorlint", "url": "..." },
+  "diagnostics": [
+    {
+      "message": "Passive voice weakens the opening.",
+      "location": { "path": "doc.md", "range": { "start": { "line": 12 } } },
+      "severity": "ERROR",
+      "code": { "value": "Acme.PassiveVoice" },
+      "suggestions": []
+    }
+  ]
+}
+```
+
+Use this when running VectorLint in reviewdog or a reviewdog-compatible CI setup.
 
 ## Exit codes
 
+The default command exits non-zero only when a finding surfaces at **`error`** severity — not for `warning`-severity findings. This lets warnings pass through CI while errors block a merge.
+
 | Code | Meaning |
 |------|---------|
-| `0` | No violations found. All files passed |
-| `1` | One or more violations found |
+| `0` | No `error`-severity findings. (`warning` findings may still be present) |
+| `1` | One or more `error`-severity findings, or an operational error (for example, a provider request failure or invalid configuration) |
 
-Exit codes make VectorLint suitable for CI pipelines. A non-zero exit blocks a merge when content fails quality checks. See [CI Integration](/ci-integration) for setup examples.
+A check rule surfaces at `error` severity when its density score is 1.0 or below, and at `warning` severity otherwise. A rule may also set `severity: error` in its frontmatter to force the `error` level. See [CI Integration](/ci-integration) for gating examples.
 
 ## Environment variables
 
@@ -89,15 +188,15 @@ VectorLint reads configuration from environment variables in addition to config 
 | `ANTHROPIC_API_KEY` | _(none)_ | API key for Anthropic |
 | `GEMINI_API_KEY` | _(none)_ | API key for Google Gemini |
 | `AZURE_OPENAI_API_KEY` | _(none)_ | API key for Azure OpenAI |
-| `SEARCH_PROVIDER` | _(none)_ | Search provider for `technical-accuracy` evaluator: `perplexity` |
+| `SEARCH_PROVIDER` | _(none)_ | Search provider for the `technical-accuracy` evaluator: `perplexity` |
 | `PERPLEXITY_API_KEY` | _(none)_ | API key for Perplexity search |
 | `CONFIDENCE_THRESHOLD` | `0.75` | Confidence gate. Lower surfaces more findings; higher surfaces fewer. |
 
-For the full environment variable reference see [Environment variables](/env-variables).
+For the full environment variable reference, including Azure OpenAI and Amazon Bedrock variables, see [Environment variables](/env-variables).
 
 ## Related
 
-- [Installation](/installation): install VectorLint globally or run with npx
-- [Configuration](/configuration): configure VectorLint for your project
-- [Handling false positives](/handling-false-positives): adjust `CONFIDENCE_THRESHOLD` and strictness
-- [CI Integration](/ci-integration): use exit codes to gate merges on content quality
+- [Installation](/installation) — install VectorLint globally or run with npx
+- [Configuration](/configuration) — configure VectorLint for your project
+- [Handling false positives](/handling-false-positives) — adjust `CONFIDENCE_THRESHOLD` and strictness
+- [CI Integration](/ci-integration) — use exit codes and output formats to gate merges

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,8 @@
           "cli-reference",
           "env-variables",
           "rule-frontmatter",
-          "troubleshooting"
+          "troubleshooting",
+          "releases"
         ]
       }
     ]

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -1,11 +1,12 @@
 ---
-title: Release notes
-description: VectorLint release history, generated from GitHub Releases.
+title: "Release notes"
+description: "VectorLint release history, mirrored from GitHub Releases."
+rss: true
 ---
 
 These notes are mirrored from the [GitHub Releases](https://github.com/TRocket-Labs/vectorlint/releases) for the VectorLint package.
 
-## 2.5.0 - 2026-03-04
+<Update label="2026-03-04" description="v2.5.0" tags={["features", "improvements"]}>
 
 ### Features
 - **User-facing `message` field**: LLM violations now include a dedicated `message` field — under 15 words, written directly to the user, with no rule references. This replaces `analysis` as the string shown in the terminal.
@@ -14,9 +15,9 @@ These notes are mirrored from the [GitHub Releases](https://github.com/TRocket-L
 ### Improvements
 - Directive guidance updated to explicitly distinguish `message` (user-facing) from `analysis` (internal reasoning not shown in UI)
 
----
+</Update>
 
-## 2.4.0 - 2026-03-04
+<Update label="2026-03-04" description="v2.4.0" tags={["features", "improvements"]}>
 
 ### Features
 - **PAT (Pay A Tax) Evaluation Technique**: New gate-check evaluation method using structured output for more reliable LLM-based assessments
@@ -29,9 +30,9 @@ These notes are mirrored from the [GitHub Releases](https://github.com/TRocket-L
 - Aligned CLI surfacing with PAT filters for consistent flag exposure
 - Tightened PAT confidence guidance for more predictable gate-check behavior
 
----
+</Update>
 
-## 2.3.0 - 2026-02-11
+<Update label="2026-02-11" description="v2.3.0">
 
 ### Features
 - **Zero-Config Mode**: Run VectorLint without any config file by adding a `VECTORLINT.md` to your
@@ -53,9 +54,9 @@ format
 
 **Full Changelog:** https://github.com/TRocket-Labs/vectorlint/compare/v2.2.0...v2.3.0
 
----
+</Update>
 
-## 2.2.0 - 2026-01-02
+<Update label="2026-01-02" description="v2.2.0" tags={["bugfixes", "features", "improvements"]}>
 
 ### Features
 - **Renamed Rule Types**: Rule types renamed for clarity — `semi-objective` → `check`, `subjective` → `judge`. Backward compatibility maintained via automatic mapping.
@@ -80,17 +81,17 @@ format
 
 **Full Changelog:** https://github.com/TRocket-Labs/vectorlint/compare/v2.1.1...v2.2.0
 
----
+</Update>
 
-## 2.1.1 - 2025-12-12
+<Update label="2025-12-12" description="v2.1.1" tags={["bugfixes"]}>
 
 ### Bug Fixes
 - **Fix Runtime Crash**: Resolved `Cannot find module` error in published package by inlining `package.json` version
 - Replaced relative runtime require with static import to prevent path resolution issues in `dist` artifacts
 
----
+</Update>
 
-## 2.1.0 - 2025-12-12
+<Update label="2025-12-12" description="v2.1.0" tags={["features"]}>
 
 ### Features
 - **Reviewdog Support**: Added `rdjson` (Reviewdog Diagnostic JSON Format) output capability
@@ -99,9 +100,9 @@ format
 
 **Full Changelog**: [v2.0.1...v2.1.0](https://github.com/TRocket-Labs/vectorlint/compare/v2.0.1...v2.1.0)
 
----
+</Update>
 
-## 2.0.1 - 2025-12-09
+<Update label="2025-12-09" description="v2.0.1" tags={["bugfixes", "features", "improvements"]}>
 
 ### Features
 - **Cascading Configuration**: Configuration now applies from general to specific patterns
@@ -117,9 +118,9 @@ format
 **Full Changelog:** https://github.com/TRocket-Labs/vectorlint/compare/v2.0.0...v2.0.1
 
 
----
+</Update>
 
-## 2.0.0 - 2025-12-05
+<Update label="2025-12-05" description="v2.0.0">
 
 An LLM-based prose linter that catches subjective writing issues like clarity, tone, and technical accuracy. Think Vale, but powered by AI.
 
@@ -147,5 +148,5 @@ npm install -g vectorlint
 
 **Full Changelog**: https://github.com/TRocket-Labs/vectorlint/commits/v2.0.0
 
----
+</Update>
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -1,0 +1,151 @@
+---
+title: Release notes
+description: VectorLint release history, generated from GitHub Releases.
+---
+
+These notes are mirrored from the [GitHub Releases](https://github.com/TRocket-Labs/vectorlint/releases) for the VectorLint package.
+
+## 2.5.0 - 2026-03-04
+
+### Features
+- **User-facing `message` field**: LLM violations now include a dedicated `message` field — under 15 words, written directly to the user, with no rule references. This replaces `analysis` as the string shown in the terminal.
+- **`analysis` in JSON output**: The `analysis` field (internal model reasoning) is now included in `--output=json` violation objects alongside `message`, giving consumers access to both.
+
+### Improvements
+- Directive guidance updated to explicitly distinguish `message` (user-facing) from `analysis` (internal reasoning not shown in UI)
+
+---
+
+## 2.4.0 - 2026-03-04
+
+### Features
+- **PAT (Pay A Tax) Evaluation Technique**: New gate-check evaluation method using structured output for more reliable LLM-based assessments
+- **Amazon Bedrock Provider**: Run VectorLint against AWS-hosted models via the Amazon Bedrock LLM provider
+- **Vercel AI SDK Integration**: Unified LLM provider interface via Vercel AI SDK, enabling consistent behavior across all providers
+- **PAT Confidence Tuning**: Expose confidence thresholds via CLI to tune PAT filter sensitivity
+- **File-Type Context**: Evaluations now receive file-type context to improve rule applicability
+
+### Improvements
+- Aligned CLI surfacing with PAT filters for consistent flag exposure
+- Tightened PAT confidence guidance for more predictable gate-check behavior
+
+---
+
+## 2.3.0 - 2026-02-11
+
+### Features
+- **Zero-Config Mode**: Run VectorLint without any config file by adding a `VECTORLINT.md` to your
+project root
+- **User Instructions Support**: Global user instructions now run alongside all rules (previously
+fallback-only)
+- **Fix Suggestions**: New `fix` field in violation output provides drop-in replacement suggestions for
+both Check and Judge evaluations
+- **Init Command Enhancements**: New `--quick` flag creates only `VECTORLINT.md`, `--full` flag creates
+both config and user instruction files
+- **Improved Evaluation Instructions**: Centralized directive with structured Role/Task/Instructions
+format
+
+### Improvements
+- Renamed internal terminology: "Style Guide" → "User Instructions" for clarity
+- Renamed evaluation types: `SubjectiveResult` → `JudgeResult`, `SemiObjectiveResult` → `CheckResult`
+- Removed redundant instruction sections from bundled preset prompts
+- Consolidated architectural documentation into CLAUDE.md
+
+**Full Changelog:** https://github.com/TRocket-Labs/vectorlint/compare/v2.2.0...v2.3.0
+
+---
+
+## 2.2.0 - 2026-01-02
+
+### Features
+- **Renamed Rule Types**: Rule types renamed for clarity — `semi-objective` → `check`, `subjective` → `judge`. Backward compatibility maintained via automatic mapping.
+- **Content Chunking**: Large documents are now automatically chunked for improved evaluation accuracy
+- **Bundled Rule Packs (Presets)**: Built-in rule packs now ship with VectorLint — no custom rules path required to get started
+- **Global Configuration**: New global config file for storing API keys and environment settings
+- **Init Command**: New `vectorlint init` command for easy project setup
+- **Token Usage Reporting**: CLI now displays input/output token counts after each evaluation
+- **Hidden Config Support**: Configuration can now be stored as a hidden file
+- **Disable Rules**: Support for disabling specific rules within a rule pack
+- **Improved Line Accuracy**: Better issue location with line numbering and fuzzy matching
+
+### Improvements
+- Refactored help output for clearer CLI usage
+- Updated documentation to reflect optional rules path
+- Improved Anthropic provider configuration and type safety
+- Simplified evaluator token usage tracking
+
+### Bug Fixes
+- Fix CLI to require explicit paths, preventing accidental directory scans
+- Fix path option description to indicate it's required
+
+**Full Changelog:** https://github.com/TRocket-Labs/vectorlint/compare/v2.1.1...v2.2.0
+
+---
+
+## 2.1.1 - 2025-12-12
+
+### Bug Fixes
+- **Fix Runtime Crash**: Resolved `Cannot find module` error in published package by inlining `package.json` version
+- Replaced relative runtime require with static import to prevent path resolution issues in `dist` artifacts
+
+---
+
+## 2.1.0 - 2025-12-12
+
+### Features
+- **Reviewdog Support**: Added `rdjson` (Reviewdog Diagnostic JSON Format) output capability
+- Enables automated code review comments and annotations in CI/CD pipelines
+- CLI now accepts `--output rdjson` flag
+
+**Full Changelog**: [v2.0.1...v2.1.0](https://github.com/TRocket-Labs/vectorlint/compare/v2.0.1...v2.1.0)
+
+---
+
+## 2.0.1 - 2025-12-09
+
+### Features
+- **Cascading Configuration**: Configuration now applies from general to specific patterns
+- Files can inherit rules from multiple matching patterns instead of just one
+- More specific patterns override settings from general patterns
+
+### Improvements
+- Updated documentation with configuration examples
+
+### Bug Fixes
+- Fix configuration resolution to properly handle multiple matching patterns
+
+**Full Changelog:** https://github.com/TRocket-Labs/vectorlint/compare/v2.0.0...v2.0.1
+
+
+---
+
+## 2.0.0 - 2025-12-05
+
+An LLM-based prose linter that catches subjective writing issues like clarity, tone, and technical accuracy. Think Vale, but powered by AI.
+
+## 🚀 Highlights
+
+- **Multiple LLM Providers**: OpenAI, Anthropic Claude, Azure OpenAI, Google Gemini
+- **Smart Scoring**: Density-based scoring (errors per 100 words) for fair evaluation
+- **Vale Integration**: Seamless integration with Vale CLI for combined analysis
+- **Technical Accuracy**: Hallucination detection with search provider support
+- **Flexible Config**: File-centric rule packs with glob-based targeting
+- **Multiple Outputs**: Native JSON and Vale-compatible JSON formats
+- **MDX Support**: Extended support for React-based documentation
+
+## 📦 Installation
+
+```bash
+npm install -g vectorlint
+```
+## Contributors
+* @ayo6706 made their first contribution in https://github.com/TRocket-Labs/vectorlint/pull/3
+* @oluwatooki-GA made their first contribution in https://github.com/TRocket-Labs/vectorlint/pull/10
+* @oshorefueled made their first contribution in https://github.com/TRocket-Labs/vectorlint/pull/11
+* @hurshore made their first contribution in https://github.com/TRocket-Labs/vectorlint/pull/23
+* @mtgr18977 made their first contribution in https://github.com/TRocket-Labs/vectorlint/pull/26
+
+**Full Changelog**: https://github.com/TRocket-Labs/vectorlint/commits/v2.0.0
+
+---
+

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -3,9 +3,69 @@ title: Troubleshooting
 description: Diagnose and fix common VectorLint issues with installation, configuration, API keys, and review output.
 ---
 
+This page covers common issues and the exact error messages VectorLint prints. If you hit an error, scan the [common error messages](#common-error-messages) below or the symptom sections that follow.
+
+## Common error messages
+
+These are the real strings VectorLint prints at v2.5.0, grouped by what triggers them.
+
+### `Invalid environment variables: LLM_PROVIDER is required and must be either ...`
+
+**Trigger:** `LLM_PROVIDER` is unset or set to a value the schema rejects.
+
 <Note>
-  VectorLint's exact error message strings are not yet documented here. If you see an error not covered on this page, check the [VectorLint GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues) or open a new one.
+  The runtime message currently lists only `azure-openai`, `anthropic`, and `openai`. This is a known stale string — the schema actually accepts five providers. The complete, correct set is below.
 </Note>
+
+**Fix:** Set `LLM_PROVIDER` to one of the supported values: `openai`, `anthropic`, `azure-openai`, `gemini`, or `amazon-bedrock`. See [Environment variables](/env-variables).
+
+### `Missing required Azure OpenAI environment variables: ...`
+
+**Trigger:** `LLM_PROVIDER=azure-openai` but one or more required Azure variables are unset.
+
+**Fix:** Set all three: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_DEPLOYMENT_NAME`. (`AZURE_OPENAI_API_VERSION` is optional and defaults to `2024-02-15-preview`.)
+
+### `Missing required Anthropic environment variables: ANTHROPIC_API_KEY`
+
+**Trigger:** `LLM_PROVIDER=anthropic` but `ANTHROPIC_API_KEY` is unset.
+
+**Fix:** Set `ANTHROPIC_API_KEY`.
+
+### `Missing required OpenAI environment variables: OPENAI_API_KEY`
+
+**Trigger:** `LLM_PROVIDER=openai` but `OPENAI_API_KEY` is unset.
+
+**Fix:** Set `OPENAI_API_KEY`.
+
+### `AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted`
+
+**Trigger:** `LLM_PROVIDER=amazon-bedrock` and exactly one of the two AWS credentials is set.
+
+**Fix:** Set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or omit both to fall back to an IAM role or an AWS credentials profile in `~/.aws/credentials`. `AWS_REGION` is required either way. See [LLM providers](/llm-providers).
+
+### `Error: Invalid output format '<value>'. Valid options: line, json, vale-json, rdjson`
+
+**Trigger:** `--output` was given a value outside the four supported formats.
+
+**Fix:** Use one of `line`, `json`, `vale-json`, or `rdjson`. See [Output formats](/cli-reference#output-formats).
+
+### `Error: no target files found to evaluate.`
+
+**Trigger:** The paths passed to VectorLint matched no files.
+
+**Fix:** Confirm the path or glob is correct and is passed correctly by your shell. Some CI shells don't expand globs the same way — quote the pattern or use `find ... | xargs vectorlint`.
+
+### `Error: rules path does not exist: <path>`
+
+**Trigger:** `RulesPath` in `.vectorlint.ini` (or `--config`) points at a directory that doesn't exist.
+
+**Fix:** Create the directory, or correct the `RulesPath` value.
+
+### `Error: The following files already exist:` (from `init`)
+
+**Trigger:** `vectorlint init` would overwrite an existing `.vectorlint.ini` or `VECTORLINT.md`.
+
+**Fix:** Re-run with `--force` to overwrite, or remove the existing files first.
 
 ## Installation issues
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,90 +1,76 @@
 ---
 title: Troubleshooting
-description: Diagnose and fix common VectorLint issues with installation, configuration, API keys, and review output.
+description: Fix common VectorLint errors with providers, configuration, and CI.
 ---
 
-If you're stuck, find what you're seeing in the table below and jump to the relevant section. Most problems fall into a handful of common causes that are quick to fix once you know where to look.
+This page covers runtime errors after VectorLint is installed. For setup, see [Installation](/installation). For config debugging, see [Project Configuration](/project-config).
 
-## Find your problem
+## Find your error
 
-| What you're seeing | Go to |
+| What you see | Go to |
 | --- | --- |
-| `vectorlint: command not found` after installing globally | [Command not found after install](#command-not-found-after-install) |
-| Install fails with a Node.js version error | [Unsupported Node version](#unsupported-node-version) |
-| `LLM_PROVIDER is required and must be either 'azure-openai', 'anthropic', or 'openai'` | [Provider not recognized](#provider-not-recognized) |
+| `vectorlint: command not found` | [Command not found](#command-not-found) |
+| `LLM_PROVIDER is required and must be either 'azure-openai', 'anthropic', or 'openai'. Received: ...` | [Provider not recognized](#provider-not-recognized) |
 | `AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted` | [Bedrock credential mismatch](#bedrock-credential-mismatch) |
-| Authentication or authorization error from your provider | [Authentication errors](#authentication-errors) |
-| The run completes but prints nothing | [No output from a run](#no-output-from-a-run) |
-| Rules you configured aren't running on a file | [Rules not running on a file](#rules-not-running-on-a-file) |
-| A warning that VECTORLINT.md exceeds 4,000 tokens | [VECTORLINT.md is too large](#vectorlintmd-is-too-large) |
-| CI fails without printing any findings | [CI fails with no findings](#ci-fails-with-no-findings) |
+| `Error: rules path does not exist: <path>` | [Rules path missing](#rules-not-running-on-a-file) |
+| Run completes but prints nothing | [No output from a run](#no-output-from-a-run) |
+| Rules you configured aren't firing | [Rules not running on a file](#rules-not-running-on-a-file) |
+| VECTORLINT.md token warning | [VECTORLINT.md too large](#vectorlintmd-is-too-large) |
+| CI exits non-zero with no findings | [CI fails with no findings](#ci-fails-with-no-findings) |
 
-For errors not listed here, check the [GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues) or open a new one.
+## Installation
 
-## Installation issues
+### Command not found
 
-### Command not found after install
-
-If `npm install -g vectorlint` succeeds but running `vectorlint` reports `command not found`, the npm global bin directory isn't on your `PATH`. Your shell only runs programs found in the directories listed there.
-
-Find the directory and add it to your shell profile (`.zshrc`, `.bashrc`, or equivalent):
+The npm global bin directory isn't on your `PATH`. Add it:
 
 ```bash
-npm bin -g                              # prints the global bin directory
-export PATH="$PATH:$(npm bin -g)"       # add it for this session
+npm bin -g
+export PATH="$PATH:$(npm bin -g)"
 ```
 
-Restart your terminal and run `vectorlint --version` to confirm.
+Add the export to your shell profile (`.zshrc`, `.bashrc`) to persist it. VectorLint requires Node.js 18+.
 
-### Unsupported Node version
-
-VectorLint requires Node.js 18 or later. If npm rejects the install with a version error, check what you have:
-
-```bash
-node --version
-```
-
-If it's below 18, upgrade with [nvm](https://github.com/nvm-sh/nvm):
-
-```bash
-nvm install --lts
-nvm use --lts
-```
-
-## Provider and API key issues
+## Provider and API keys
 
 ### Provider not recognized
 
-You'll see this error when `LLM_PROVIDER` is unset or set to a value VectorLint doesn't accept:
+The full error:
 
 ```
-LLM_PROVIDER is required and must be either 'azure-openai', 'anthropic', or 'openai'
+LLM_PROVIDER is required and must be either 'azure-openai', 'anthropic', or 'openai'. Received: undefined
 ```
 
 <Note>
-  This message is out of date. It lists only three providers, but VectorLint accepts five: `openai`, `anthropic`, `azure-openai`, `gemini`, and `amazon-bedrock`. Set `LLM_PROVIDER` to one of these — `gemini` and `amazon-bedrock` are valid even though the message omits them.
+  This message is stale. It lists three providers, but VectorLint accepts five: `openai`, `anthropic`, `azure-openai`, `gemini`, and `amazon-bedrock`. The schema validates all five; only the error string is wrong.
 </Note>
 
-Set the provider in your `.env` file or `~/.vectorlint/config.toml`:
+Set `LLM_PROVIDER` in `.env` or `~/.vectorlint/config.toml`:
 
 ```toml
 [env]
 LLM_PROVIDER = "openai"
 ```
 
-See [Environment variables](/env-variables) for the full reference.
+See [Environment variables](/env-variables) for the full list.
+
+### Bedrock credential mismatch
+
+```
+AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted
+```
+
+AWS credentials are an all-or-nothing pair. Either set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or omit both to fall back to an IAM role or `~/.aws/credentials` profile. `AWS_REGION` is always required. See [LLM providers](/llm-providers) for full Bedrock setup.
 
 ### Authentication errors
 
-A `401`, `Invalid API key`, or similar authentication error from your provider means the key is missing, incorrect, or not being read from where you think.
-
-First confirm the variable is actually set in your environment:
+A `401` or `Invalid API key` from your provider means the key is missing or `LLM_PROVIDER` doesn't match the key you set. Confirm the variable is present:
 
 ```bash
 echo $OPENAI_API_KEY
 ```
 
-If it's empty, set it in your project `.env` file (which takes precedence) or in `~/.vectorlint/config.toml`. Use the variable name that matches your provider exactly — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `AZURE_OPENAI_API_KEY` — and make sure `LLM_PROVIDER` matches the key you've set:
+Set the key in `.env` or `~/.vectorlint/config.toml` using the exact variable name for your provider: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `AZURE_OPENAI_API_KEY`:
 
 ```toml
 [env]
@@ -92,19 +78,9 @@ LLM_PROVIDER = "anthropic"
 ANTHROPIC_API_KEY = "sk-ant-..."
 ```
 
-### Bedrock credential mismatch
-
-With `LLM_PROVIDER=amazon-bedrock`, VectorLint rejects a configuration where exactly one of the two AWS credentials is set:
-
-```
-AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted
-```
-
-AWS credentials are an all-or-nothing pair. Either set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or omit both to fall back to an IAM role or an AWS credentials profile in `~/.aws/credentials`. `AWS_REGION` is required either way. See [LLM providers](/llm-providers) for the full Bedrock setup.
-
 ### No search provider for technical-accuracy rules
 
-Rules using `evaluator: technical-accuracy` need a search provider to verify claims against external sources. Without one they return reduced-confidence or no results. Add Perplexity:
+Rules using `evaluator: technical-accuracy` need a search provider. Without one they return reduced-confidence results. Add Perplexity:
 
 ```toml
 [env]
@@ -112,80 +88,76 @@ SEARCH_PROVIDER = "perplexity"
 PERPLEXITY_API_KEY = "pplx-..."
 ```
 
-## Configuration and scoring
+## Configuration
 
 ### No output from a run
 
-When a run finishes with no findings and no errors, it usually means one of three things.
+Three causes, in order of likelihood:
 
-The most common is a `CONFIDENCE_THRESHOLD` set too high, which filters out everything the model finds. Lower it temporarily to confirm:
+1. **Threshold too high.** `CONFIDENCE_THRESHOLD` filters everything. Test with a lower value:
 
-```bash
-CONFIDENCE_THRESHOLD=0.5 vectorlint doc.md
-```
+   ```bash
+   CONFIDENCE_THRESHOLD=0.5 vectorlint doc.md
+   ```
 
-If findings appear, your threshold is filtering too aggressively. See [Handling false positives](/handling-false-positives) to tune it.
+   If findings appear, tune the threshold. See [Handling false positives](/handling-false-positives).
 
-Second, the file may match a pattern with `RunRules=` (empty) — the intentional "skip drafts" behavior. Check your `.vectorlint.ini` for a pattern that matches the file and confirm it's the one you expect.
+2. **Empty RunRules.** The file matches a pattern with `RunRules=` (empty), the intentional "skip this file" syntax. Check `.vectorlint.ini`.
 
-Third, the content may simply pass. Test with a file you know has issues to confirm the rule is working.
+3. **Content passes.** Run against a file you know has issues to confirm the rule works.
 
 ### Rules not running on a file
 
-If a file you expect to be reviewed produces no output, work through the match chain in order.
+Work through the match chain:
 
-The glob pattern has to match the path. `**/*.md` matches any Markdown file anywhere; `content/docs/**/*.md` matches only files under `content/docs/`. A file at `docs/api.md` will not match `content/docs/**/*.md`.
+1. The glob must match the file path. `**/*.md` matches any Markdown file; `content/docs/**/*.md` does not match `docs/api.md`.
 
-If you use custom rule packs, `RulesPath` in `.vectorlint.ini` must point at the directory containing your pack subdirectories:
+2. `RulesPath` must point at the directory containing your pack subdirectories:
 
 ```ini
 RulesPath=.github/rules
 ```
 
-Finally, the pack name has to match the directory name exactly. `RunRules=Acme` looks for a subdirectory called `Acme` (case-sensitive) inside `RulesPath`. See [Project Configuration](/project-config) for the full reference.
+3. The pack name in `RunRules` must match the directory name exactly (case-sensitive). `RunRules=Acme` looks for an `Acme/` subdirectory inside `RulesPath`.
+
+See [Project Configuration](/project-config) for cascade semantics: multiple matching patterns accumulate, so a file can run packs from more than one section.
 
 ### VECTORLINT.md is too large
 
-VectorLint warns when `VECTORLINT.md` exceeds roughly 4,000 tokens. A file that large degrades LLM precision and raises API costs on every run, since it's prepended to every evaluation.
+VectorLint warns at ~4,000 tokens. A file that large degrades LLM precision and raises costs because it's prepended to every evaluation call.
 
-Target under 800 tokens. Move specific, detailed rules into dedicated rule pack files where they apply selectively instead of globally. [Defining your style rules](/style-guide) has an extraction prompt for turning a full style guide into a compact `VECTORLINT.md`.
+Target under 800 tokens. Move detailed rules into dedicated rule pack files. [Defining your style rules](/style-guide) has an extraction prompt for distilling a full style guide.
 
-### Cascading configuration surprises
-
-VectorLint applies every matching pattern from general to specific, and rule packs accumulate — a file can run rules from more than one pattern. For a file at `content/docs/api.md`, both `**/*.md` and `content/docs/**/*.md` match, so the file runs packs from both.
-
-If a file is running unexpected rules, trace which patterns match its path. See [Project Configuration](/project-config) for the cascade reference.
-
-## CI issues
+## CI
 
 ### CI fails with no findings
 
-When the VectorLint step exits non-zero but prints nothing, the run failed before it could surface findings. Check the usual culprits.
+The run failed before evaluation. Check:
 
-The API key secret may not be reaching the job. Confirm the secret is defined and referenced correctly:
+1. The API key secret isn't reaching the job:
 
-```yaml
-env:
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-```
+   ```yaml
+   env:
+     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+   ```
 
-The Node.js version in CI may be below 18. Add an explicit setup step:
+2. Node.js is below 18:
 
-```yaml
-- uses: actions/setup-node@v4
-  with:
-    node-version: lts/*
-```
+   ```yaml
+   - uses: actions/setup-node@v4
+     with:
+       node-version: lts/*
+   ```
 
-Finally, some CI shells don't expand globs the way your local shell does. If a glob matches nothing, quote it or resolve files explicitly:
+3. Globs aren't expanding. Some CI shells don't expand unquoted globs. Resolve files explicitly:
 
-```bash
-find content/docs -name "*.md" | xargs vectorlint
-```
+   ```bash
+   find content/docs -name "*.md" | xargs vectorlint
+   ```
 
 ## Getting more help
 
-- [VectorLint GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues) — search existing issues or open a new one
-- [CLI reference](/cli-reference) — confirm command syntax, flags, and exit codes
-- [Environment variables](/env-variables) — verify variable names and precedence
-- [Project Configuration](/project-config) — debug `.vectorlint.ini` pattern matching
+- [GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues)
+- [CLI reference](/cli-reference): flags and exit codes
+- [Environment variables](/env-variables): variable names and precedence
+- [Project Configuration](/project-config): `.vectorlint.ini` pattern matching

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -3,151 +3,88 @@ title: Troubleshooting
 description: Diagnose and fix common VectorLint issues with installation, configuration, API keys, and review output.
 ---
 
-This page covers common issues and the exact error messages VectorLint prints. If you hit an error, scan the [common error messages](#common-error-messages) below or the symptom sections that follow.
+If you're stuck, find what you're seeing in the table below and jump to the relevant section. Most problems fall into a handful of common causes that are quick to fix once you know where to look.
 
-## Common error messages
+## Find your problem
 
-These are the real strings VectorLint prints at v2.5.0, grouped by what triggers them.
+| What you're seeing | Go to |
+| --- | --- |
+| `vectorlint: command not found` after installing globally | [Command not found after install](#command-not-found-after-install) |
+| Install fails with a Node.js version error | [Unsupported Node version](#unsupported-node-version) |
+| `LLM_PROVIDER is required and must be either 'azure-openai', 'anthropic', or 'openai'` | [Provider not recognized](#provider-not-recognized) |
+| `AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted` | [Bedrock credential mismatch](#bedrock-credential-mismatch) |
+| Authentication or authorization error from your provider | [Authentication errors](#authentication-errors) |
+| The run completes but prints nothing | [No output from a run](#no-output-from-a-run) |
+| Rules you configured aren't running on a file | [Rules not running on a file](#rules-not-running-on-a-file) |
+| A warning that VECTORLINT.md exceeds 4,000 tokens | [VECTORLINT.md is too large](#vectorlintmd-is-too-large) |
+| CI fails without printing any findings | [CI fails with no findings](#ci-fails-with-no-findings) |
 
-### `Invalid environment variables: LLM_PROVIDER is required and must be either ...`
-
-**Trigger:** `LLM_PROVIDER` is unset or set to a value the schema rejects.
-
-<Note>
-  The runtime message currently lists only `azure-openai`, `anthropic`, and `openai`. This is a known stale string — the schema actually accepts five providers. The complete, correct set is below.
-</Note>
-
-**Fix:** Set `LLM_PROVIDER` to one of the supported values: `openai`, `anthropic`, `azure-openai`, `gemini`, or `amazon-bedrock`. See [Environment variables](/env-variables).
-
-### `Missing required Azure OpenAI environment variables: ...`
-
-**Trigger:** `LLM_PROVIDER=azure-openai` but one or more required Azure variables are unset.
-
-**Fix:** Set all three: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_DEPLOYMENT_NAME`. (`AZURE_OPENAI_API_VERSION` is optional and defaults to `2024-02-15-preview`.)
-
-### `Missing required Anthropic environment variables: ANTHROPIC_API_KEY`
-
-**Trigger:** `LLM_PROVIDER=anthropic` but `ANTHROPIC_API_KEY` is unset.
-
-**Fix:** Set `ANTHROPIC_API_KEY`.
-
-### `Missing required OpenAI environment variables: OPENAI_API_KEY`
-
-**Trigger:** `LLM_PROVIDER=openai` but `OPENAI_API_KEY` is unset.
-
-**Fix:** Set `OPENAI_API_KEY`.
-
-### `AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted`
-
-**Trigger:** `LLM_PROVIDER=amazon-bedrock` and exactly one of the two AWS credentials is set.
-
-**Fix:** Set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or omit both to fall back to an IAM role or an AWS credentials profile in `~/.aws/credentials`. `AWS_REGION` is required either way. See [LLM providers](/llm-providers).
-
-### `Error: Invalid output format '<value>'. Valid options: line, json, vale-json, rdjson`
-
-**Trigger:** `--output` was given a value outside the four supported formats.
-
-**Fix:** Use one of `line`, `json`, `vale-json`, or `rdjson`. See [Output formats](/cli-reference#output-formats).
-
-### `Error: no target files found to evaluate.`
-
-**Trigger:** The paths passed to VectorLint matched no files.
-
-**Fix:** Confirm the path or glob is correct and is passed correctly by your shell. Some CI shells don't expand globs the same way — quote the pattern or use `find ... | xargs vectorlint`.
-
-### `Error: rules path does not exist: <path>`
-
-**Trigger:** `RulesPath` in `.vectorlint.ini` (or `--config`) points at a directory that doesn't exist.
-
-**Fix:** Create the directory, or correct the `RulesPath` value.
-
-### `Error: The following files already exist:` (from `init`)
-
-**Trigger:** `vectorlint init` would overwrite an existing `.vectorlint.ini` or `VECTORLINT.md`.
-
-**Fix:** Re-run with `--force` to overwrite, or remove the existing files first.
+For errors not listed here, check the [GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues) or open a new one.
 
 ## Installation issues
 
-### VectorLint command not found after global install
+### Command not found after install
 
-**Symptom:** Running `vectorlint` after `npm install -g vectorlint` returns "command not found."
+If `npm install -g vectorlint` succeeds but running `vectorlint` reports `command not found`, the npm global bin directory isn't on your `PATH`. Your shell only runs programs found in the directories listed there.
 
-**Cause:** npm's global bin directory is not on your `PATH`.
-
-**Fix:** Find your npm global bin directory and add it to your `PATH`:
+Find the directory and add it to your shell profile (`.zshrc`, `.bashrc`, or equivalent):
 
 ```bash
-npm bin -g
+npm bin -g                              # prints the global bin directory
+export PATH="$PATH:$(npm bin -g)"       # add it for this session
 ```
 
-Add the output path to your shell profile (`.bashrc`, `.zshrc`, or equivalent):
+Restart your terminal and run `vectorlint --version` to confirm.
 
-```bash
-export PATH="$PATH:/path/from/npm/bin"
-```
+### Unsupported Node version
 
-Restart your terminal and try again.
-
----
-
-### Node.js version error on install
-
-**Symptom:** npm returns an error referencing an unsupported Node.js version during install.
-
-**Cause:** VectorLint requires Node.js 18 or later.
-
-**Fix:** Check your current version:
+VectorLint requires Node.js 18 or later. If npm rejects the install with a version error, check what you have:
 
 ```bash
 node --version
 ```
 
-If it's below 18, upgrade using [nvm](https://github.com/nvm-sh/nvm):
+If it's below 18, upgrade with [nvm](https://github.com/nvm-sh/nvm):
 
 ```bash
 nvm install --lts
 nvm use --lts
 ```
 
----
+## Provider and API key issues
 
-## API key and provider issues
+### Provider not recognized
 
-### No output: VectorLint runs but produces nothing
+You'll see this error when `LLM_PROVIDER` is unset or set to a value VectorLint doesn't accept:
 
-**Symptom:** `vectorlint doc.md` completes silently with no findings and no errors.
+```
+LLM_PROVIDER is required and must be either 'azure-openai', 'anthropic', or 'openai'
+```
 
-**Possible causes and fixes:**
+<Note>
+  This message is out of date. It lists only three providers, but VectorLint accepts five: `openai`, `anthropic`, `azure-openai`, `gemini`, and `amazon-bedrock`. Set `LLM_PROVIDER` to one of these — `gemini` and `amazon-bedrock` are valid even though the message omits them.
+</Note>
 
-1. **`CONFIDENCE_THRESHOLD` is too high.** Lower it temporarily to see if the model is finding candidates that are being filtered out:
-   ```bash
-   CONFIDENCE_THRESHOLD=0.5 vectorlint doc.md
-   ```
-   If findings appear, your threshold is filtering too aggressively. Adjust it in your config.
+Set the provider in your `.env` file or `~/.vectorlint/config.toml`:
 
-2. **The file matches a pattern with `RunRules=` (empty).** Check your `.vectorlint.ini` for a pattern that matches the file and has no rules assigned. This is intentional skip behavior for drafts. Confirm the file path matches the pattern you expect.
+```toml
+[env]
+LLM_PROVIDER = "openai"
+```
 
-3. **The content genuinely passes.** If you've lowered the threshold and still see nothing, the content may actually meet your standards. Try a file you know has issues to confirm the rule is working.
+See [Environment variables](/env-variables) for the full reference.
 
----
+### Authentication errors
 
-### Authentication error from LLM provider
+A `401`, `Invalid API key`, or similar authentication error from your provider means the key is missing, incorrect, or not being read from where you think.
 
-**Symptom:** VectorLint returns an authentication or authorization error when running a review.
-
-**Cause:** API key is missing, incorrect, or not being read from the right location.
-
-**Fix:** Verify the key is set and readable:
+First confirm the variable is actually set in your environment:
 
 ```bash
-# Check if the variable is set in your environment
 echo $OPENAI_API_KEY
 ```
 
-If empty, set it in your project `.env` file or `~/.vectorlint/config.toml`. Confirm the variable name matches exactly: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `AZURE_OPENAI_API_KEY` depending on your provider.
-
-Also confirm `LLM_PROVIDER` matches the key you've set:
+If it's empty, set it in your project `.env` file (which takes precedence) or in `~/.vectorlint/config.toml`. Use the variable name that matches your provider exactly — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `AZURE_OPENAI_API_KEY` — and make sure `LLM_PROVIDER` matches the key you've set:
 
 ```toml
 [env]
@@ -155,17 +92,19 @@ LLM_PROVIDER = "anthropic"
 ANTHROPIC_API_KEY = "sk-ant-..."
 ```
 
-See [Environment variables](/env-variables) for the full variable reference.
+### Bedrock credential mismatch
 
----
+With `LLM_PROVIDER=amazon-bedrock`, VectorLint rejects a configuration where exactly one of the two AWS credentials is set:
 
-### Search provider not working for TechnicalAccuracy rules
+```
+AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must both be provided or both be omitted
+```
 
-**Symptom:** Rules using `evaluator: technical-accuracy` produce no findings or return an error about search.
+AWS credentials are an all-or-nothing pair. Either set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or omit both to fall back to an IAM role or an AWS credentials profile in `~/.aws/credentials`. `AWS_REGION` is required either way. See [LLM providers](/llm-providers) for the full Bedrock setup.
 
-**Cause:** No search provider is configured.
+### No search provider for technical-accuracy rules
 
-**Fix:** Add a search provider to your config:
+Rules using `evaluator: technical-accuracy` need a search provider to verify claims against external sources. Without one they return reduced-confidence or no results. Add Perplexity:
 
 ```toml
 [env]
@@ -173,80 +112,80 @@ SEARCH_PROVIDER = "perplexity"
 PERPLEXITY_API_KEY = "pplx-..."
 ```
 
-Without a search provider, `technical-accuracy` evaluators cannot verify facts against external sources and will return reduced-confidence or no results.
+## Configuration and scoring
 
----
+### No output from a run
 
-## Configuration issues
+When a run finishes with no findings and no errors, it usually means one of three things.
+
+The most common is a `CONFIDENCE_THRESHOLD` set too high, which filters out everything the model finds. Lower it temporarily to confirm:
+
+```bash
+CONFIDENCE_THRESHOLD=0.5 vectorlint doc.md
+```
+
+If findings appear, your threshold is filtering too aggressively. See [Handling false positives](/handling-false-positives) to tune it.
+
+Second, the file may match a pattern with `RunRules=` (empty) — the intentional "skip drafts" behavior. Check your `.vectorlint.ini` for a pattern that matches the file and confirm it's the one you expect.
+
+Third, the content may simply pass. Test with a file you know has issues to confirm the rule is working.
 
 ### Rules not running on a file
 
-**Symptom:** A file you expect to be checked produces no output even though rules are configured.
+If a file you expect to be reviewed produces no output, work through the match chain in order.
 
-**Possible causes and fixes:**
+The glob pattern has to match the path. `**/*.md` matches any Markdown file anywhere; `content/docs/**/*.md` matches only files under `content/docs/`. A file at `docs/api.md` will not match `content/docs/**/*.md`.
 
-1. **Glob pattern doesn't match.** Test your pattern mentally against the file path. `**/*.md` matches any `.md` file in any subdirectory. `content/docs/**/*.md` only matches files under `content/docs/`. A file at `docs/api.md` would not match `content/docs/**/*.md`.
+If you use custom rule packs, `RulesPath` in `.vectorlint.ini` must point at the directory containing your pack subdirectories:
 
-2. **`RulesPath` not set or incorrect.** If you're using custom rule packs, confirm `RulesPath` in `.vectorlint.ini` points to the directory containing your pack subdirectories:
-   ```ini
-   RulesPath=.github/rules
-   ```
+```ini
+RulesPath=.github/rules
+```
 
-3. **Pack name doesn't match directory name.** `RunRules=Acme` looks for a subdirectory called `Acme` (case-sensitive) inside `RulesPath`. Confirm the directory exists and the name matches exactly.
+Finally, the pack name has to match the directory name exactly. `RunRules=Acme` looks for a subdirectory called `Acme` (case-sensitive) inside `RulesPath`. See [Project Configuration](/project-config) for the full reference.
 
----
+### VECTORLINT.md is too large
 
-### VECTORLINT.md token warning
+VectorLint warns when `VECTORLINT.md` exceeds roughly 4,000 tokens. A file that large degrades LLM precision and raises API costs on every run, since it's prepended to every evaluation.
 
-**Symptom:** VectorLint emits a warning that `VECTORLINT.md` exceeds approximately 4,000 tokens.
+Target under 800 tokens. Move specific, detailed rules into dedicated rule pack files where they apply selectively instead of globally. [Defining your style rules](/style-guide) has an extraction prompt for turning a full style guide into a compact `VECTORLINT.md`.
 
-**Cause:** The file is too large to serve as reliable global context. Excessively large context degrades LLM precision and increases API costs.
+### Cascading configuration surprises
 
-**Fix:** Trim `VECTORLINT.md` to under 800 tokens, the practical working target. Move specific or detailed rules into dedicated rule pack files where they can be applied selectively rather than globally. See [Defining your style rules](/style-guide) for the extraction prompt that converts a full style guide into a compact `VECTORLINT.md`.
+VectorLint applies every matching pattern from general to specific, and rule packs accumulate — a file can run rules from more than one pattern. For a file at `content/docs/api.md`, both `**/*.md` and `content/docs/**/*.md` match, so the file runs packs from both.
 
----
-
-### Cascading configuration not behaving as expected
-
-**Symptom:** A file is running the wrong rules.
-
-**Cause:** VectorLint applies all matching patterns from general to specific. More specific patterns override settings from general ones, but rule packs accumulate. A file can run rules from multiple patterns.
-
-**Fix:** Trace which patterns match your file path. For a file at `content/docs/api.md`, both `**/*.md` and `content/docs/**/*.md` match. The file runs rule packs from both patterns. See [Project Configuration](/project-config) for the full cascade reference.
-
----
+If a file is running unexpected rules, trace which patterns match its path. See [Project Configuration](/project-config) for the cascade reference.
 
 ## CI issues
 
-### CI pipeline fails immediately with no findings output
+### CI fails with no findings
 
-**Symptom:** The VectorLint step in CI exits with a non-zero code but prints no findings.
+When the VectorLint step exits non-zero but prints nothing, the run failed before it could surface findings. Check the usual culprits.
 
-**Possible causes and fixes:**
+The API key secret may not be reaching the job. Confirm the secret is defined and referenced correctly:
 
-1. **API key secret not passed to the job.** Confirm the secret is defined in your CI environment and referenced correctly in the workflow:
-   ```yaml
-   env:
-     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-   ```
+```yaml
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
 
-2. **Node.js version in CI is below 18.** Add an explicit setup step:
-   ```yaml
-   - uses: actions/setup-node@v4
-     with:
-       node-version: lts/*
-   ```
+The Node.js version in CI may be below 18. Add an explicit setup step:
 
-3. **Glob pattern in the run command doesn't expand correctly.** Some CI shells don't expand globs the same way as your local shell. Quote the pattern or use `find`:
-   ```bash
-   find content/docs -name "*.md" | xargs vectorlint
-   ```
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: lts/*
+```
 
----
+Finally, some CI shells don't expand globs the way your local shell does. If a glob matches nothing, quote it or resolve files explicitly:
+
+```bash
+find content/docs -name "*.md" | xargs vectorlint
+```
 
 ## Getting more help
 
-- [VectorLint GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues): search existing issues or open a new one
-- [CLI reference](/cli-reference): confirm command syntax and flags
-- [Environment variables](/env-variables): verify variable names and precedence
-- [Project Configuration](/project-config): debug `.vectorlint.ini` pattern matching
+- [VectorLint GitHub issues](https://github.com/TRocket-Labs/vectorlint/issues) — search existing issues or open a new one
+- [CLI reference](/cli-reference) — confirm command syntax, flags, and exit codes
+- [Environment variables](/env-variables) — verify variable names and precedence
+- [Project Configuration](/project-config) — debug `.vectorlint.ini` pattern matching


### PR DESCRIPTION
## Summary

Completes the documentation set on `release-docs` against v2.5.0: rewrites the CLI reference to the full surface, backfills the troubleshooting page with error strings and a tighter structure, adds a release-notes page, and fixes a bundled-template bug. 

## Changes

**CLI reference (`docs/cli-reference.mdx`)** — rewritten to the full v2.5.0 surface
- Documents the `validate` subcommand and all `init` flags (`--quick`, `--full`, `--force`)
- Covers `-v/--verbose`, `--show-prompt`, `--show-prompt-trunc`, `--debug-json`, `--config`, and `--debug-json` artifacts (`.vectorlint/runs/<model>/<id>.json`)
- New Output formats section: `line`, `json`, `vale-json`, `rdjson` with their JSON shapes
- Corrects exit-code semantics: exit 1 only on `error`-severity findings (or operational errors), not any violation

**Troubleshooting (`docs/troubleshooting.mdx`)** — error-first triage
- Router table maps exact terminal strings to the fix section
- Keeps only the error strings that mislead or hide the fix: the stale `LLM_PROVIDER` message (lists 3 providers, schema accepts 5) and the Bedrock all-or-nothing credential check
- Cuts the self-explanatory messages and AI-templated `Symptom/Cause/Fix` labels
- ~1170 → ~740 words, same problem coverage

**Release notes (`docs/releases.mdx`)** — new, native Mintlify format
- One `<Update>` component per release (v2.0.0 → v2.5.0), mirrored verbatim from GitHub Releases
- `label`/`description`/`tags` drive the right-sidebar TOC and tag filters; `rss: true` enables a discoverable feed
- Added to the Reference nav group

**Bundled template (`.vectorlint.ini.example`)**
- Stripped two `GrammarChecker.strictness=` overrides (parsed but not wired into scoring at v2.5.0) and a misleading "higher strictness" comment
- Fixed a broken link in `CREATING_RULES.md` (missing leading dot)
