### PR TITLE
docs: add canonical meta tag and update description

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,7 +12,12 @@
     "light": "/logo/light.svg"
   },
   "favicon": "/favicon.svg",
-  "description": "An LLM-based prose linter that lets you enforce your style guide in one prompt.",
+  "description": "A programmable content review harness for AI agents.",
+  "seo": {
+    "metatags": {
+      "canonical": "https://docs.vectorlint.dev"
+    }
+  },
   "navigation": {
     "groups": [
       {

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "VectorLint is a large language model (LLM)-based prose linter that enforces your style guide in one prompt."
+description: "A programmable content review harness for AI agents."
 ---
 
 ## What is VectorLint?


### PR DESCRIPTION
## Why

VectorLint's documentation is currently not marked as canonical, so search engines have no signal that this is the authoritative source for VectorLint docs. This can lead to duplicate-content penalties or incorrect canonicalization in search results.

## Changes

- Add `seo.metatags.canonical` pointing to `https://docs.vectorlint.dev` in `docs/docs.json` so search engines recognize the hosted docs as the canonical source.
- Update the site description (and matching `introduction.mdx` frontmatter) to **"A programmable content review harness for AI agents."** to align the public description with the product's current positioning.