### PR TITLE
ci(doc-drift): bump Node to 22 and scope gh calls to repo

### DIFF
--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install Pi
         run: npm install -g @earendil-works/pi-coding-agent@0.79.6
@@ -121,7 +121,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           DIFF_PATH="$GITHUB_WORKSPACE/pr/.doc-drift-input.diff"
-          gh pr diff ${{ github.event.issue.number }} > "$DIFF_PATH"
+          gh pr diff --repo ${{ github.repository }} ${{ github.event.issue.number }} > "$DIFF_PATH"
           echo "Diff size: $(wc -l < "$DIFF_PATH") lines"
 
       - name: Build agent message
@@ -168,11 +168,11 @@ jobs:
         run: |
           REPORT_FILES=$(ls "$GITHUB_WORKSPACE"/pr/.doc-drift-*.md 2>/dev/null | sort -V)
           if [ -z "$REPORT_FILES" ]; then
-            gh pr comment ${{ github.event.issue.number }} \
+            gh pr comment --repo ${{ github.repository }} ${{ github.event.issue.number }} \
               --body "Doc drift check completed but produced no output. Check the [Actions log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
           else
             for file in $REPORT_FILES; do
-              gh pr comment ${{ github.event.issue.number }} --body-file "$file"
+              gh pr comment --repo ${{ github.repository }} ${{ github.event.issue.number }} --body-file "$file"
             done
           fi
 
@@ -181,5 +181,5 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr comment ${{ github.event.issue.number }} \
+          gh pr comment --repo ${{ github.repository }} ${{ github.event.issue.number }} \
             --body "Doc drift check failed. Check the [Actions log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."


### PR DESCRIPTION
## Summary

The doc drift workflow crashed on its first post-merge run. Pi 0.79.6 requires Node ≥22.19.0, but the workflow set up Node 20, so Pi threw `TypeError: webidl.util.markAsUncloneable is not a function` from undici and exited before running. A second failure followed: the `gh pr comment` calls infer the repo from the current directory's git remote, but the workspace root isn't a git checkout after `main` and `pr` are cloned into subdirectories, so the failure-comment step errored with `fatal: not a git repository`.

## What this PR covers

- Bumps `node-version` from 20 to 22 so Pi meets its engine requirement.
- Adds `--repo` to every `gh pr diff` and `gh pr comment` call so they resolve the repository explicitly instead of relying on the working directory.

## How to test / verify

- Comment `/check-docs` on a PR. The `Show Pi version` step should print the version and the run should proceed to the drift check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation drift checks to run on Node.js 22.
  * Improved pull request reporting reliability by explicitly targeting the repository when retrieving changes and posting results.
  * Enhanced failure notifications for documentation drift checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->